### PR TITLE
(GH-58) Store build log in build artifacts

### DIFF
--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -119,7 +119,15 @@ Task("Build")
             .WithProperty("TreatWarningsAsErrors","true")
             .WithTarget("Build")
             .SetMaxCpuCount(0)
-            .SetConfiguration(BuildParameters.Configuration);
+            .SetConfiguration(BuildParameters.Configuration)
+            .WithLogger(
+                Context.Tools.Resolve("MSBuild.ExtensionPack.Loggers.dll").FullPath,
+                "XmlFileLogger",
+                string.Format(
+                    "logfile=\"{0}\";invalidCharReplacement=_;verbosity=Detailed;encoding=UTF-8",
+                    BuildParameters.Paths.Files.BuildLogFilePath)
+            );
+
 
     // TODO: Need to have an XBuild step here as well
     MSBuild(BuildParameters.SolutionFilePath, msbuildSettings);;

--- a/Cake.Recipe/Content/paths.cake
+++ b/Cake.Recipe/Content/paths.cake
@@ -41,6 +41,7 @@ public class BuildPaths
         // Files
         var testCoverageOutputFilePath = ((DirectoryPath)testCoverageDirectory).CombineWithFilePath("OpenCover.xml");
         var solutionInfoFilePath = ((DirectoryPath)BuildParameters.SourceDirectoryPath).CombineWithFilePath("SolutionInfo.cs");
+        var buildLogFilePath = ((DirectoryPath)buildDirectoryPath).CombineWithFilePath("MsBuild.log");
 
         var repoFilesPaths = new FilePath[] {
             "LICENSE",
@@ -76,7 +77,8 @@ public class BuildPaths
             context,
             repoFilesPaths,
             testCoverageOutputFilePath,
-            solutionInfoFilePath
+            solutionInfoFilePath,
+            buildLogFilePath
             );
 
         return new BuildPaths
@@ -95,16 +97,20 @@ public class BuildFiles
 
     public FilePath SolutionInfoFilePath { get; private set; }
 
+    public FilePath BuildLogFilePath { get; private set; }
+
     public BuildFiles(
         ICakeContext context,
         FilePath[] repoFilesPaths,
         FilePath testCoverageOutputFilePath,
-        FilePath solutionInfoFilePath
+        FilePath solutionInfoFilePath,
+        FilePath buildLogFilePath
         )
     {
         RepoFilesPaths = Filter(context, repoFilesPaths);
         TestCoverageOutputFilePath = testCoverageOutputFilePath;
         SolutionInfoFilePath = solutionInfoFilePath;
+        BuildLogFilePath = buildLogFilePath;
     }
 
     private static FilePath[] Filter(ICakeContext context, FilePath[] files)

--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -10,3 +10,4 @@
 #tool nuget:?package=KuduSync.NET&version=1.3.1
 #tool nuget:?package=Wyam&version=0.16.1
 #tool nuget:?package=gitlink&version=2.4.1
+#tool nuget:?package=MSBuild.Extension.Pack&version=1.9.0


### PR DESCRIPTION
Stores the MSBuild log as XML file in the build artifacts. Uses [XmlFileLogger](http://www.msbuildextensionpack.com/help/4.0.5.0/html/242ab4fd-c2e2-f6aa-325b-7588725aed24.htm) from [MSBuild Extension Pack](http://www.msbuildextensionpack.com/).