### PR TITLE
GH-82: Extend DupFinder properties in ToolSettings

### DIFF
--- a/Cake.Recipe/Content/resharper.cake
+++ b/Cake.Recipe/Content/resharper.cake
@@ -11,12 +11,22 @@ Task("DupFinder")
         ShowText = true,
         OutputFile = BuildParameters.Paths.Directories.DupFinderTestResults.CombineWithFilePath("dupfinder.xml"),
         ExcludeCodeRegionsByNameSubstring = new string [] { "DupFinder Exclusion" },
-        ThrowExceptionOnFindingDuplicates = true
+        ThrowExceptionOnFindingDuplicates = ToolSettings.DupFinderThrowExceptionOnFindingDuplicates ?? true
     };
 
     if(ToolSettings.DupFinderExcludePattern != null)
     {
         settings.ExcludePattern = ToolSettings.DupFinderExcludePattern;
+    }
+
+    if(ToolSettings.DupFinderExcludeFilesByStartingCommentSubstring != null)
+    {
+        settings.ExcludeFilesByStartingCommentSubstring = ToolSettings.DupFinderExcludeFilesByStartingCommentSubstring;
+    }
+
+    if(ToolSettings.DupFinderDiscardCost != null)
+    {
+        settings.DiscardCost = ToolSettings.DupFinderDiscardCost.Value;
     }
 
     DupFinder(BuildParameters.SolutionFilePath, settings);

--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -1,6 +1,9 @@
 public static class ToolSettings
 {
     public static string[] DupFinderExcludePattern { get; private set; }
+    public static string[] DupFinderExcludeFilesByStartingCommentSubstring { get; private set; }
+    public static int? DupFinderDiscardCost { get; private set; }
+    public static bool? DupFinderThrowExceptionOnFindingDuplicates { get; private set; }
     public static string TestCoverageFilter { get; private set; }
     public static string TestCoverageExcludeByAttribute { get; private set; }
     public static string TestCoverageExcludeByFile { get; private set; }
@@ -14,13 +17,19 @@ public static class ToolSettings
         string testCoverageExcludeByAttribute = null,
         string testCoverageExcludeByFile = null,
         PlatformTarget? buildPlatformTarget = null,
-        DirectoryPath outputDirectory = null
+        DirectoryPath outputDirectory = null,
+        string[] dupFinderExcludeFilesByStartingCommentSubstring = null,
+        int? dupFinderDiscardCost = null,
+        bool? dupFinderThrowExceptionOnFindingDuplicates = null
     )
     {
         context.Information("Setting up tools...");
         
         // TODO: Remove hard coding of Cake.Example.Tests
         DupFinderExcludePattern = dupFinderExcludePattern ?? new string[] { context.MakeAbsolute(context.Environment.WorkingDirectory) + "/src/Cake.Example.Tests/*.cs" };
+        DupFinderExcludeFilesByStartingCommentSubstring = dupFinderExcludeFilesByStartingCommentSubstring;
+        DupFinderDiscardCost = dupFinderDiscardCost;
+        DupFinderThrowExceptionOnFindingDuplicates = dupFinderThrowExceptionOnFindingDuplicates;
         TestCoverageFilter = testCoverageFilter ?? "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]*";
         TestCoverageExcludeByAttribute = testCoverageExcludeByAttribute ?? "*.ExcludeFromCodeCoverage*";
         TestCoverageExcludeByFile = testCoverageExcludeByFile ?? "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs";


### PR DESCRIPTION
Adds in additional properties to pass along to `DupFinderSettings`.

It may also be worth considering creating nested classes to start to delineate the various settings?  Just adding these new parameters + properties starts to feel messy.  If that's something that is desired, I could potentially re-work this PR to include it.