### PR TITLE
(GH-92) Create reports for MsBuild warnings

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -13,6 +13,7 @@
 #addin nuget:?package=Cake.Kudu&version=0.4.0
 #addin nuget:?package=Cake.Incubator&version=1.0.48
 #addin nuget:?package=Cake.Figlet&version=0.4.0
+#addin nuget:?package=Cake.CodeAnalysisReporting&version=0.1.1
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));

--- a/Cake.Recipe/Content/analyzing.cake
+++ b/Cake.Recipe/Content/analyzing.cake
@@ -2,6 +2,29 @@
 // TASK DEFINITIONS
 ///////////////////////////////////////////////////////////////////////////////
 
+var msBuildCodeAnalysisTask = Task("MsBuildCodeAnalysisReport")
+    .IsDependentOn("Build")
+    .Does(() => 
+{
+    EnsureDirectoryExists(BuildParameters.Paths.Directories.CodeAnalysisResults);
+
+    Information("Create MsBuild code analysis report by rule...");
+    var fileName = BuildParameters.Paths.Directories.CodeAnalysisResults.CombineWithFilePath("ByRule.html");
+    CreateMsBuildCodeAnalysisReport(
+        BuildParameters.Paths.Files.BuildLogFilePath,
+        CodeAnalysisReport.MsBuildXmlFileLoggerByRule,
+        fileName);
+    Information("MsBuild code analysis report by rule was written to: {0}", fileName.FullPath);
+
+    Information("Create MsBuild code analysis report by assembly...");
+    fileName = BuildParameters.Paths.Directories.CodeAnalysisResults.CombineWithFilePath("ByAssembly.html");
+    CreateMsBuildCodeAnalysisReport(
+        BuildParameters.Paths.Files.BuildLogFilePath,
+        CodeAnalysisReport.MsBuildXmlFileLoggerByAssembly,
+        BuildParameters.Paths.Directories.CodeAnalysisResults.CombineWithFilePath("ByAssembly.html"));
+    Information("MsBuild code analysis report by assembly was written to: {0}", fileName.FullPath);
+});
+
 var dupFinderTask = Task("DupFinder")
     .IsDependentOn("Clean")
     .Does(() => RequireTool(ReSharperTools, () => {
@@ -94,5 +117,6 @@ var inspectCodeTask = Task("InspectCode")
 });
 
 var analyzeTask = Task("Analyze")
+    .IsDependentOn("MsBuildCodeAnalysisReport")
     .IsDependentOn("DupFinder")
     .IsDependentOn("InspectCode");

--- a/Cake.Recipe/Content/paths.cake
+++ b/Cake.Recipe/Content/paths.cake
@@ -27,6 +27,7 @@ public class BuildPaths
         var chocolateyNuspecDirectory = "./nuspec/chocolatey";
 
         var testResultsDirectory = buildDirectoryPath + "/TestResults";
+        var codeAnalysisResultsDirectory = testResultsDirectory + "/CodeAnalysis";
         var inspectCodeResultsDirectory = testResultsDirectory + "/InspectCode";
         var dupFinderResultsDirectory = testResultsDirectory + "/DupFinder";
         var NUnitTestResultsDirectory = testResultsDirectory + "/NUnit";
@@ -65,6 +66,7 @@ public class BuildPaths
             nugetNuspecDirectory,
             chocolateyNuspecDirectory,
             testResultsDirectory,
+            codeAnalysisResultsDirectory,
             inspectCodeResultsDirectory,
             dupFinderResultsDirectory,
             NUnitTestResultsDirectory,
@@ -147,6 +149,7 @@ public class BuildDirectories
     public DirectoryPath NugetNuspecDirectory { get; private set; }
     public DirectoryPath ChocolateyNuspecDirectory { get; private set; }
     public DirectoryPath TestResults { get; private set; }
+    public DirectoryPath CodeAnalysisResults { get; private set; }
     public DirectoryPath InspectCodeTestResults { get; private set; }
     public DirectoryPath DupFinderTestResults { get; private set; }
     public DirectoryPath NUnitTestResults { get; private set; }
@@ -174,6 +177,7 @@ public class BuildDirectories
         DirectoryPath nugetNuspecDirectory,
         DirectoryPath chocolateyNuspecDirectory,
         DirectoryPath testResults,
+        DirectoryPath codeAnalysisResults,
         DirectoryPath inspectCodeTestResults,
         DirectoryPath dupFinderTestResults,
         DirectoryPath nunitTestResults,
@@ -200,6 +204,7 @@ public class BuildDirectories
         NugetNuspecDirectory = nugetNuspecDirectory;
         ChocolateyNuspecDirectory = chocolateyNuspecDirectory;
         TestResults = testResults;
+        CodeAnalysisResults = codeAnalysisResults;
         InspectCodeTestResults = inspectCodeTestResults;
         DupFinderTestResults = dupFinderTestResults;
         NUnitTestResults = nunitTestResults;


### PR DESCRIPTION
Creates reports for MsBuild warnings using Cake.CodeAnalysisReporting.

Fixes #92 