### PR TITLE
(GH-105) Added codecov report uploading

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -3,6 +3,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #addin nuget:?package=Cake.CodeAnalysisReporting&version=0.1.1
+#addin nuget:?package=Cake.Codecov&version=0.2.0
 #addin nuget:?package=Cake.Coveralls&version=0.4.0
 #addin nuget:?package=Cake.Figlet&version=0.4.0
 #addin nuget:?package=Cake.Git&version=0.15.0

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -413,7 +413,9 @@ public class Builder
         BuildParameters.Tasks.PackageTask.IsDependentOn("Test");
         BuildParameters.Tasks.PackageTask.IsDependentOn("Create-NuGet-Packages");
         BuildParameters.Tasks.PackageTask.IsDependentOn("Create-Chocolatey-Packages");
+        BuildParameters.Tasks.UploadCodecovReportTask.IsDependentOn("Test");
         BuildParameters.Tasks.UploadCoverageReportTask.IsDependentOn("Test");
+        BuildParameters.Tasks.AppVeyorTask.IsDependentOn("Upload-Codecov-Report");
         BuildParameters.Tasks.AppVeyorTask.IsDependentOn("Upload-Coverage-Report");
         BuildParameters.Tasks.AppVeyorTask.IsDependentOn("Publish-Chocolatey-Packages");
         BuildParameters.IsDotNetCoreBuild = false;
@@ -434,7 +436,9 @@ public class Builder
         BuildParameters.Tasks.PackageTask.IsDependentOn("Test");
         BuildParameters.Tasks.PackageTask.IsDependentOn("Create-NuGet-Packages");
         BuildParameters.Tasks.PackageTask.IsDependentOn("Create-Chocolatey-Packages");
+        BuildParameters.Tasks.UploadCodecovReportTask.IsDependentOn("Test");
         BuildParameters.Tasks.UploadCoverageReportTask.IsDependentOn("Test");
+        BuildParameters.Tasks.AppVeyorTask.IsDependentOn("Upload-Codecov-Report");
         BuildParameters.Tasks.AppVeyorTask.IsDependentOn("Upload-Coverage-Report");
         BuildParameters.Tasks.AppVeyorTask.IsDependentOn("Publish-Chocolatey-Packages");
         BuildParameters.IsDotNetCoreBuild = true;

--- a/Cake.Recipe/Content/codecov.cake
+++ b/Cake.Recipe/Content/codecov.cake
@@ -1,0 +1,27 @@
+///////////////////////////////////////////////////////////////////////////////
+// TASK DEFINITIONS
+///////////////////////////////////////////////////////////////////////////////
+
+BuildParameters.Tasks.UploadCodecovReportTask = Task("Upload-Codecov-Report")
+    .WithCriteria(() => FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
+    .WithCriteria(() => BuildParameters.IsMainRepository)
+    .WithCriteria(() => BuildParameters.CanPublishToCodecov)
+    .Does(() => RequireTool(CodecovTool, () => {
+        var settings = new CodecovSettings {
+            Files = new[] { BuildParameters.Paths.Files.TestCoverageOutputFilePath) },
+            Token = BuildParameters.Codecov.RepoToken
+        };
+        if (BuildParameters.Version != null &&
+            !string.IsNullOrEmpty(BuildParameters.Version.FullSemVersion) &&
+            BuildParameters.IsRunningOnAppveyor)
+        {
+            // Required to work correctly with appveyor because environment changes isn't detected until cake is done running.
+            var buildVersion = string.Format("{0}.build.{1}",
+                BuildParameters.Version.FullSemVersion,
+                BuildSystem.AppVeyor.Build.Number);
+            settings.EnvironmentVariables = new Dictionary<string, string> { { "APPVEYOR_BUILD_VERSION", buildVersion }};
+        }
+
+        Codecov(settings);
+    })
+);

--- a/Cake.Recipe/Content/codecov.cake
+++ b/Cake.Recipe/Content/codecov.cake
@@ -9,7 +9,8 @@ BuildParameters.Tasks.UploadCodecovReportTask = Task("Upload-Codecov-Report")
     .Does(() => RequireTool(CodecovTool, () => {
         var settings = new CodecovSettings {
             Files = new[] { BuildParameters.Paths.Files.TestCoverageOutputFilePath.ToString() },
-            Token = BuildParameters.Codecov.RepoToken
+            Token = BuildParameters.Codecov.RepoToken,
+            Required = true
         };
         if (BuildParameters.Version != null &&
             !string.IsNullOrEmpty(BuildParameters.Version.FullSemVersion) &&
@@ -24,4 +25,9 @@ BuildParameters.Tasks.UploadCodecovReportTask = Task("Upload-Codecov-Report")
 
         Codecov(settings);
     })
-);
+).OnError (exception =>
+{
+    Error(exception.Message);
+    Information("Upload-Codecov-Report Task failed, but continuing with next Task...");
+    publishingError = true;
+});

--- a/Cake.Recipe/Content/codecov.cake
+++ b/Cake.Recipe/Content/codecov.cake
@@ -8,17 +8,17 @@ BuildParameters.Tasks.UploadCodecovReportTask = Task("Upload-Codecov-Report")
     .WithCriteria(() => BuildParameters.CanPublishToCodecov)
     .Does(() => RequireTool(CodecovTool, () => {
         var settings = new CodecovSettings {
-            Files = new[] { BuildParameters.Paths.Files.TestCoverageOutputFilePath) },
+            Files = new[] { BuildParameters.Paths.Files.TestCoverageOutputFilePath.ToString() },
             Token = BuildParameters.Codecov.RepoToken
         };
         if (BuildParameters.Version != null &&
             !string.IsNullOrEmpty(BuildParameters.Version.FullSemVersion) &&
-            BuildParameters.IsRunningOnAppveyor)
+            BuildParameters.IsRunningOnAppVeyor)
         {
             // Required to work correctly with appveyor because environment changes isn't detected until cake is done running.
             var buildVersion = string.Format("{0}.build.{1}",
                 BuildParameters.Version.FullSemVersion,
-                BuildSystem.AppVeyor.Build.Number);
+                BuildSystem.AppVeyor.Environment.Build.Number);
             settings.EnvironmentVariables = new Dictionary<string, string> { { "APPVEYOR_BUILD_VERSION", buildVersion }};
         }
 

--- a/Cake.Recipe/Content/credentials.cake
+++ b/Cake.Recipe/Content/credentials.cake
@@ -106,6 +106,12 @@ public class AppVeyorCredentials
     }
 }
 
+public class CodecovCredentials : CoverallsCredentials
+{
+    public CodecovCredentials(string repoToken)
+        : base(repoToken) { }
+}
+
 public class CoverallsCredentials
 {
     public string RepoToken { get; private set; }
@@ -191,6 +197,12 @@ public static AppVeyorCredentials GetAppVeyorCredentials(ICakeContext context)
 {
     return new AppVeyorCredentials(
         context.EnvironmentVariable(Environment.AppVeyorApiTokenVariable));
+}
+
+public static CodecovCredentials GetCodecovCredentials(ICakeContext context)
+{
+    return new CodecovCredentials(
+        context.EnvironmentVariable(Environment.CodecovRepoTokenVariable));
 }
 
 public static CoverallsCredentials GetCoverallsCredentials(ICakeContext context)

--- a/Cake.Recipe/Content/environment.cake
+++ b/Cake.Recipe/Content/environment.cake
@@ -17,6 +17,7 @@ public static class Environment
     public static string TwitterAccessTokenVariable { get; private set; }
     public static string TwitterAccessTokenSecretVariable { get; private set; }
     public static string AppVeyorApiTokenVariable { get; private set; }
+    public static string CodecovRepoTokenVariable { get; private set; }
     public static string CoverallsRepoTokenVariable { get; private set; }
     public static string MicrosoftTeamsWebHookUrlVariable { get; private set; }
     public static string WyamAccessTokenVariable { get; private set; }
@@ -41,6 +42,7 @@ public static class Environment
         string twitterAccessTokenVariable = null,
         string twitterAccessTokenSecretVariable = null,
         string appVeyorApiTokenVariable = null,
+        string codecovRepoTokenVariable = null,
         string coverallsRepoTokenVariable = null,
         string microsoftTeamsWebHookUrlVariable = null,
         string wyamAccessTokenVariable = null,
@@ -64,6 +66,7 @@ public static class Environment
         TwitterAccessTokenVariable = twitterAccessTokenVariable ?? "TWITTER_ACCESS_TOKEN";
         TwitterAccessTokenSecretVariable = twitterAccessTokenSecretVariable ?? "TWITTER_ACCESS_TOKEN_SECRET";
         AppVeyorApiTokenVariable = appVeyorApiTokenVariable ?? "APPVEYOR_API_TOKEN";
+        CodecovRepoTokenVariable = codecovRepoTokenVariable ?? "CODECOV_REPO_TOKEN";
         CoverallsRepoTokenVariable = coverallsRepoTokenVariable ?? "COVERALLS_REPO_TOKEN";
         MicrosoftTeamsWebHookUrlVariable = microsoftTeamsWebHookUrlVariable ?? "MICROSOFTTEAMS_WEBHOOKURL";
         WyamAccessTokenVariable = wyamAccessTokenVariable ?? "WYAM_ACCESS_TOKEN";

--- a/Cake.Recipe/Content/gitversion.cake
+++ b/Cake.Recipe/Content/gitversion.cake
@@ -5,6 +5,7 @@ public class BuildVersion
     public string Milestone { get; private set; }
     public string CakeVersion { get; private set; }
     public string InformationalVersion { get; private set; }
+    public string FullSemVersion { get; private set; }
 
     public static BuildVersion CalculatingSemanticVersion(
         ICakeContext context)
@@ -18,6 +19,7 @@ public class BuildVersion
         string semVersion = null;
         string milestone = null;
         string informationalVersion = null;
+        string fullSemVersion = null;
 
         if (context.IsRunningOnWindows())
         {
@@ -45,6 +47,7 @@ public class BuildVersion
             semVersion = assertedVersions.LegacySemVerPadded;
             informationalVersion = assertedVersions.InformationalVersion;
             milestone = string.Concat(version);
+            fullSemVersion = assertedVersions.FullSemVer;
 
             context.Information("Calculated Semantic Version: {0}", semVersion);
         }
@@ -67,7 +70,8 @@ public class BuildVersion
             SemVersion = semVersion,
             Milestone = milestone,
             CakeVersion = cakeVersion,
-            InformationalVersion = informationalVersion
+            InformationalVersion = informationalVersion,
+            FullSemVer = fullSemVersion
         };
     }
 }

--- a/Cake.Recipe/Content/gitversion.cake
+++ b/Cake.Recipe/Content/gitversion.cake
@@ -71,7 +71,7 @@ public class BuildVersion
             Milestone = milestone,
             CakeVersion = cakeVersion,
             InformationalVersion = informationalVersion,
-            FullSemVer = fullSemVersion
+            FullSemVersion = fullSemVersion
         };
     }
 }

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -26,6 +26,7 @@ public static class BuildParameters
     public static NuGetCredentials NuGet { get; private set; }
     public static ChocolateyCredentials Chocolatey { get; private set; }
     public static AppVeyorCredentials AppVeyor { get; private set; }
+    public static CodecovCredentials Codecov { get; private set; }
     public static CoverallsCredentials Coveralls { get; private set; }
     public static WyamCredentials Wyam { get; private set; }
     public static BuildVersion Version { get; private set; }
@@ -53,6 +54,7 @@ public static class BuildParameters
     public static FilePath MilestoneReleaseNotesFilePath { get; private set; }
     public static FilePath FullReleaseNotesFilePath { get; private set; }
 
+    public static bool ShouldRunCodecov { get; private set; }
     public static bool ShouldPublishMyGet { get; private set; }
     public static bool ShouldPublishChocolatey { get; private set; }
     public static bool ShouldPublishNuGet { get; private set; }
@@ -160,6 +162,16 @@ public static class BuildParameters
         }
     }
 
+    public static bool CanPublishToCodecov
+    {
+        get
+        {
+            return ShouldRunCodecov &&
+                (!string.IsNullOrEmpty(BuildParameters.Codecov.RepoToken) ||
+                BuildParameters.IsRunningOnAppVeyor);
+        }
+    }
+
     public static bool CanPublishToCoveralls
     {
         get
@@ -250,6 +262,7 @@ public static class BuildParameters
         bool shouldPublishGitHub = true,
         bool shouldGenerateDocumentation = true,
         bool shouldExecuteGitLink = true,
+        bool shouldRunCodecov = true,
         DirectoryPath wyamRootDirectoryPath = null,
         DirectoryPath wyamPublishDirectoryPath = null,
         FilePath wyamConfigurationFile = null,
@@ -294,6 +307,7 @@ public static class BuildParameters
         ShouldDownloadFullReleaseNotes = shouldDownloadFullReleaseNotes;
         ShouldDownloadMilestoneReleaseNotes = shouldDownloadMilestoneReleaseNotes;
         ShouldNotifyBetaReleases = shouldNotifyBetaReleases;
+        ShouldRunCodecov = shouldRunCodecov;
 
         MilestoneReleaseNotesFilePath = milestoneReleaseNotesFilePath ?? RootDirectoryPath.CombineWithFilePath("CHANGELOG.md");
         FullReleaseNotesFilePath = fullReleaseNotesFilePath ?? RootDirectoryPath.CombineWithFilePath("ReleaseNotes.md");
@@ -325,6 +339,7 @@ public static class BuildParameters
         NuGet = GetNuGetCredentials(context);
         Chocolatey = GetChocolateyCredentials(context);
         AppVeyor = GetAppVeyorCredentials(context);
+        Codecov = GetCodecovCredentials(context);
         Coveralls = GetCoverallsCredentials(context);
         Wyam = GetWyamCredentials(context);
         IsPublishBuild = new [] {

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -22,6 +22,7 @@ public class BuildTasks
     public CakeTaskBuilder<ActionTask> PublishDocsTask { get; set; }
     public CakeTaskBuilder<ActionTask> CreateChocolateyPackagesTask { get; set; }
     public CakeTaskBuilder<ActionTask> PublishChocolateyPackagesTask { get; set; }
+    public CakeTaskBuilder<ActionTask> UploadCodecovReportTask { get; set; }
     public CakeTaskBuilder<ActionTask> UploadCoverageReportTask { get; set; }
     public CakeTaskBuilder<ActionTask> CreateReleaseNotesTask { get; set; }
     public CakeTaskBuilder<ActionTask> ExportReleaseNotesTask { get; set; }

--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -2,7 +2,7 @@
 // TOOLS
 ///////////////////////////////////////////////////////////////////////////////
 
-private const string CodecovTool = "#tool nuget:?package=codecov&version=1.0.0";
+private const string CodecovTool = "#tool nuget:?package=codecov&version=1.0.1";
 private const string CoverallsTool = "#tool nuget:?package=coveralls.io&version=1.3.4";
 private const string GitReleaseManagerTool = "#tool nuget:?package=gitreleasemanager&version=0.5.0";
 private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.2";

--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -2,6 +2,7 @@
 // TOOLS
 ///////////////////////////////////////////////////////////////////////////////
 
+private const string CodecovTool = "#tool nuget:?package=codecov&version=1.0.0";
 private const string CoverallsTool = "#tool nuget:?package=coveralls.io&version=1.3.4";
 private const string GitReleaseManagerTool = "#tool nuget:?package=gitreleasemanager&version=0.5.0";
 private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.2";


### PR DESCRIPTION
This PR implements the ability to upload coverage reports to codecov.

By default a coverage report is uploaded to codecov if the user doesn't disable the feature.
This should cause no problems for users with public repositories as a new codecov project is automatically created when the report is first pushed to codecov (although it may report an error on github the first time the report is published as there is no previous report to compare it with).

Noted as a WIP currently as there seem to be a bug where Cake.Codecov reports an error even when there isn't any (looking into it now).

This PR have been uploaded to my personal account, and can be tested by changing the load url in any supported cake addin using Cake.Recipe to https://www.myget.org/F/wormie-nugets/api/v2?package=Cake.Recipe

fixes #105 