### PR TITLE
GH106: Changed Coverage Report task to a publish step

### DIFF
--- a/Cake.Recipe/Content/coveralls.cake
+++ b/Cake.Recipe/Content/coveralls.cake
@@ -20,4 +20,9 @@ BuildParameters.Tasks.UploadCoverallsReportTask = Task("Upload-Coveralls-Report"
             Warning("Unable to publish to Coveralls, as necessary credentials are not available");
         }
     })
-);
+).OnError (exception =>
+{
+    Error(exception.Message);
+    Information("Upload-Coveralls-Report Task failed, but continuing with next Task...");
+    publishingError = true;
+});


### PR DESCRIPTION
**NOTE:** This PR depends on the existing PR #114 .
That one needs to be merged first, and this then should be rebased afterwards.

fixes #106 