### PR TITLE
Downgrade GitLink to latest stable release

### DIFF
--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -10,7 +10,7 @@ private const string ReSharperTools = "#tool nuget:?package=JetBrains.ReSharper.
 private const string ReSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.2.0";
 private const string KuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.3.1";
 private const string WyamTool = "#tool nuget:?package=Wyam&version=0.17.7";
-private const string GitLinkTool = "#tool nuget:?package=gitlink&version=2.4.1";
+private const string GitLinkTool = "#tool nuget:?package=gitlink&version=2.4.0";
 private const string MSBuildExtensionPackTool = "#tool nuget:?package=MSBuild.Extension.Pack&version=1.9.0";
 private const string XUnitTool = "#tool nuget:?package=xunit.runner.console&version=2.1.0";
 private const string NUnitTool = "#tool nuget:?package=NUnit.ConsoleRunner&version=3.4.1";


### PR DESCRIPTION
Since GitLink 2.4.1 is deleted on nuget.org downgrade GitLink to latest stable release.

Fixes #122 