### PR TITLE
GH129: Changed to use SolutionFilePath directory with GitLink

### DIFF
--- a/Cake.Recipe/Content/gitlink.cake
+++ b/Cake.Recipe/Content/gitlink.cake
@@ -8,7 +8,7 @@ public void ExecuteGitLink()
         Information("Starting GitLink Execution...");
 
         var gitLinkSettings = new GitLinkSettings {
-            SolutionFileName = string.Concat(BuildParameters.SourceDirectoryPath.GetDirectoryName(), "/", BuildParameters.SolutionFilePath.GetFilename())
+            SolutionFileName = BuildParameters.SolutionFilePath.ToString()
         };
 
 


### PR DESCRIPTION
This PR changes the path passed to GitLink to be similar to the path passed to msbuild/dotnet utility.

fixes #129 

/cc @gep13 