### PR TITLE
Added TestDirectoryPath and TestProjectPattern

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -300,7 +300,7 @@ public static class BuildParameters
         SolutionDirectoryPath = solutionDirectoryPath ?? SourceDirectoryPath.Combine(Title);
         RootDirectoryPath = rootDirectoryPath ?? context.MakeAbsolute(context.Environment.WorkingDirectory);
         TestDirectoryPath = testDirectoryPath ?? sourceDirectoryPath;
-        TestProjectPattern = testProjectPattern ?? "/**/*Tests.csproj";
+        TestProjectPattern = testProjectPattern ?? (IsDotNetCoreBuild ? "/**/*Tests.csproj" : "/**/*Tests.dll");
         ResharperSettingsFileName = resharperSettingsFileName ?? string.Format("{0}.sln.DotSettings", Title);
         RepositoryOwner = repositoryOwner ?? string.Empty;
         RepositoryName = repositoryName ?? Title;

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -37,6 +37,8 @@ public static class BuildParameters
     public static FilePath SolutionFilePath { get; private set; }
     public static DirectoryPath SourceDirectoryPath { get; private set; }
     public static DirectoryPath SolutionDirectoryPath { get; private set; }
+    public static DirectoryPath TestDirectoryPath { get; private set; }
+    public static string TestProjectPattern { get; private set; }
     public static string Title { get; private set; }
     public static string ResharperSettingsFileName { get; private set; }
     public static string RepositoryOwner { get; private set; }
@@ -248,6 +250,8 @@ public static class BuildParameters
         FilePath solutionFilePath = null,
         DirectoryPath solutionDirectoryPath = null,
         DirectoryPath rootDirectoryPath = null,
+        DirectoryPath testDirectoryPath = null,
+        string testProjectPattern = null,
         string resharperSettingsFileName = null,
         string repositoryOwner = null,
         string repositoryName = null,
@@ -295,6 +299,8 @@ public static class BuildParameters
         SolutionFilePath = solutionFilePath ?? SourceDirectoryPath.CombineWithFilePath(Title + ".sln");
         SolutionDirectoryPath = solutionDirectoryPath ?? SourceDirectoryPath.Combine(Title);
         RootDirectoryPath = rootDirectoryPath ?? context.MakeAbsolute(context.Environment.WorkingDirectory);
+        TestDirectoryPath = testDirectoryPath ?? sourceDirectoryPath;
+        TestProjectPattern = testProjectPattern ?? "/**/*Tests.csproj";
         ResharperSettingsFileName = resharperSettingsFileName ?? string.Format("{0}.sln.DotSettings", Title);
         RepositoryOwner = repositoryOwner ?? string.Empty;
         RepositoryName = repositoryName ?? Title;

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -38,7 +38,7 @@ public static class BuildParameters
     public static DirectoryPath SourceDirectoryPath { get; private set; }
     public static DirectoryPath SolutionDirectoryPath { get; private set; }
     public static DirectoryPath TestDirectoryPath { get; private set; }
-    public static string TestProjectPattern { get; private set; }
+    public static string TestFilePattern { get; private set; }
     public static string Title { get; private set; }
     public static string ResharperSettingsFileName { get; private set; }
     public static string RepositoryOwner { get; private set; }
@@ -251,7 +251,7 @@ public static class BuildParameters
         DirectoryPath solutionDirectoryPath = null,
         DirectoryPath rootDirectoryPath = null,
         DirectoryPath testDirectoryPath = null,
-        string testProjectPattern = null,
+        string testFilePattern = null,
         string resharperSettingsFileName = null,
         string repositoryOwner = null,
         string repositoryName = null,
@@ -300,7 +300,7 @@ public static class BuildParameters
         SolutionDirectoryPath = solutionDirectoryPath ?? SourceDirectoryPath.Combine(Title);
         RootDirectoryPath = rootDirectoryPath ?? context.MakeAbsolute(context.Environment.WorkingDirectory);
         TestDirectoryPath = testDirectoryPath ?? sourceDirectoryPath;
-        TestProjectPattern = testProjectPattern ?? (IsDotNetCoreBuild ? "/**/*Tests.csproj" : "/**/*Tests.dll");
+        TestFilePattern = testFilePattern;
         ResharperSettingsFileName = resharperSettingsFileName ?? string.Format("{0}.sln.DotSettings", Title);
         RepositoryOwner = repositoryOwner ?? string.Empty;
         RepositoryName = repositoryName ?? Title;

--- a/Cake.Recipe/Content/testing.cake
+++ b/Cake.Recipe/Content/testing.cake
@@ -22,7 +22,7 @@ BuildParameters.Tasks.TestNUnitTask = Task("Test-NUnit")
         EnsureDirectoryExists(BuildParameters.Paths.Directories.NUnitTestResults);
 
         OpenCover(tool => {
-            tool.NUnit3(GetFiles(BuildParameters.Paths.Directories.PublishedNUnitTests + "/**/*.Tests.dll"), new NUnit3Settings {
+            tool.NUnit3(GetFiles(BuildParameters.Paths.Directories.PublishedNUnitTests + BuildParameters.TestProjectPattern), new NUnit3Settings {
                 NoResults = true
             });
         },
@@ -44,7 +44,7 @@ BuildParameters.Tasks.TestxUnitTask = Task("Test-xUnit")
     EnsureDirectoryExists(BuildParameters.Paths.Directories.xUnitTestResults);
 
         OpenCover(tool => {
-            tool.XUnit2(GetFiles(BuildParameters.Paths.Directories.PublishedxUnitTests + "/**/*.Tests.dll"), new XUnit2Settings {
+            tool.XUnit2(GetFiles(BuildParameters.Paths.Directories.PublishedxUnitTests + BuildParameters.TestProjectPattern), new XUnit2Settings {
                 OutputDirectory = BuildParameters.Paths.Directories.xUnitTestResults,
                 XmlReport = true,
                 NoAppDomain = true
@@ -72,7 +72,7 @@ BuildParameters.Tasks.TestMSTestTask = Task("Test-MSTest")
     EnsureDirectoryExists(BuildParameters.Paths.Directories.MSTestTestResults);
 
     // TODO: Need to add OpenCover here
-    MSTest(GetFiles(BuildParameters.Paths.Directories.PublishedMSTestTests + "/**/*.Tests.dll"), new MSTestSettings() {
+    MSTest(GetFiles(BuildParameters.Paths.Directories.PublishedMSTestTests + BuildParameters.TestProjectPattern), new MSTestSettings() {
         NoIsolation = false
     });
 });
@@ -95,7 +95,7 @@ BuildParameters.Tasks.TestVSTestTask = Task("Test-VSTest")
     }
 
     OpenCover(
-		tool => { tool.VSTest(GetFiles(BuildParameters.Paths.Directories.PublishedVSTestTests + "/**/*.Tests.dll"), vsTestSettings); },
+		tool => { tool.VSTest(GetFiles(BuildParameters.Paths.Directories.PublishedVSTestTests + BuildParameters.TestProjectPattern), vsTestSettings); },
         BuildParameters.Paths.Files.TestCoverageOutputFilePath,
         new OpenCoverSettings() { ReturnTargetCodeOffset = 0 }
             .WithFilter(ToolSettings.TestCoverageFilter)
@@ -116,7 +116,7 @@ BuildParameters.Tasks.TestFixieTask = Task("Test-Fixie")
         EnsureDirectoryExists(BuildParameters.Paths.Directories.FixieTestResults);
 
         OpenCover(tool => {
-            tool.Fixie(GetFiles(BuildParameters.Paths.Directories.PublishedFixieTests + "/**/*.Tests.dll"), new FixieSettings  {
+            tool.Fixie(GetFiles(BuildParameters.Paths.Directories.PublishedFixieTests + BuildParameters.TestProjectPattern), new FixieSettings  {
                 XUnitXml = BuildParameters.Paths.Directories.FixieTestResults + "TestResult.xml"
             });
         },

--- a/Cake.Recipe/Content/testing.cake
+++ b/Cake.Recipe/Content/testing.cake
@@ -22,7 +22,7 @@ BuildParameters.Tasks.TestNUnitTask = Task("Test-NUnit")
         EnsureDirectoryExists(BuildParameters.Paths.Directories.NUnitTestResults);
 
         OpenCover(tool => {
-            tool.NUnit3(GetFiles(BuildParameters.Paths.Directories.PublishedNUnitTests + BuildParameters.TestProjectPattern), new NUnit3Settings {
+            tool.NUnit3(GetFiles(BuildParameters.Paths.Directories.PublishedNUnitTests + BuildParameters.TestFilePattern ?? "/**/*Tests.dll"), new NUnit3Settings {
                 NoResults = true
             });
         },
@@ -44,7 +44,7 @@ BuildParameters.Tasks.TestxUnitTask = Task("Test-xUnit")
     EnsureDirectoryExists(BuildParameters.Paths.Directories.xUnitTestResults);
 
         OpenCover(tool => {
-            tool.XUnit2(GetFiles(BuildParameters.Paths.Directories.PublishedxUnitTests + BuildParameters.TestProjectPattern), new XUnit2Settings {
+            tool.XUnit2(GetFiles(BuildParameters.Paths.Directories.PublishedxUnitTests + BuildParameters.TestFilePattern ?? "/**/*Tests.dll"), new XUnit2Settings {
                 OutputDirectory = BuildParameters.Paths.Directories.xUnitTestResults,
                 XmlReport = true,
                 NoAppDomain = true
@@ -72,7 +72,7 @@ BuildParameters.Tasks.TestMSTestTask = Task("Test-MSTest")
     EnsureDirectoryExists(BuildParameters.Paths.Directories.MSTestTestResults);
 
     // TODO: Need to add OpenCover here
-    MSTest(GetFiles(BuildParameters.Paths.Directories.PublishedMSTestTests + BuildParameters.TestProjectPattern), new MSTestSettings() {
+    MSTest(GetFiles(BuildParameters.Paths.Directories.PublishedMSTestTests + BuildParameters.TestFilePattern ?? "/**/*Tests.dll"), new MSTestSettings() {
         NoIsolation = false
     });
 });
@@ -95,7 +95,7 @@ BuildParameters.Tasks.TestVSTestTask = Task("Test-VSTest")
     }
 
     OpenCover(
-		tool => { tool.VSTest(GetFiles(BuildParameters.Paths.Directories.PublishedVSTestTests + BuildParameters.TestProjectPattern), vsTestSettings); },
+		tool => { tool.VSTest(GetFiles(BuildParameters.Paths.Directories.PublishedVSTestTests + BuildParameters.TestFilePattern ?? "/**/*Tests.dll"), vsTestSettings); },
         BuildParameters.Paths.Files.TestCoverageOutputFilePath,
         new OpenCoverSettings() { ReturnTargetCodeOffset = 0 }
             .WithFilter(ToolSettings.TestCoverageFilter)
@@ -116,7 +116,7 @@ BuildParameters.Tasks.TestFixieTask = Task("Test-Fixie")
         EnsureDirectoryExists(BuildParameters.Paths.Directories.FixieTestResults);
 
         OpenCover(tool => {
-            tool.Fixie(GetFiles(BuildParameters.Paths.Directories.PublishedFixieTests + BuildParameters.TestProjectPattern), new FixieSettings  {
+            tool.Fixie(GetFiles(BuildParameters.Paths.Directories.PublishedFixieTests + BuildParameters.TestFilePattern ?? "/**/*Tests.dll"), new FixieSettings  {
                 XUnitXml = BuildParameters.Paths.Directories.FixieTestResults + "TestResult.xml"
             });
         },
@@ -138,7 +138,7 @@ BuildParameters.Tasks.DotNetCoreTestTask = Task("DotNetCore-Test")
     .IsDependentOn("Install-OpenCover")
     .Does(() => {
 
-    var projects = GetFiles(BuildParameters.TestDirectoryPath + BuildParameters.TestProjectPattern);
+    var projects = GetFiles(BuildParameters.TestDirectoryPath + BuildParameters.TestFilePattern ?? "/**/*Tests.csproj");
 
     foreach (var project in projects)
     {

--- a/Cake.Recipe/Content/testing.cake
+++ b/Cake.Recipe/Content/testing.cake
@@ -138,7 +138,7 @@ BuildParameters.Tasks.DotNetCoreTestTask = Task("DotNetCore-Test")
     .IsDependentOn("Install-OpenCover")
     .Does(() => {
 
-    var projects = GetFiles(BuildParameters.SourceDirectoryPath + "/**/*Tests.csproj");
+    var projects = GetFiles(BuildParameters.TestDirectoryPath + BuildParameters.TestProjectPattern);
 
     foreach (var project in projects)
     {


### PR DESCRIPTION
This Pull Request is to resolve #132 

I attempted to solve two concerns.

1. An explicit path to the folder where the test are stored.  In the event that tests are not in the `"./src"` directory path.
2. Allow an override for the globber pattern in the event you want to execute only `"/**/*UnitTests.csproj"` and exclude `"/**/*IntegrationTests.csproj"`  