### PR TITLE
GH145: Increase JetBrains.ReSharper.CommandLineTools version

### DIFF
--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -6,7 +6,7 @@ private const string CodecovTool = "#tool nuget:?package=codecov&version=1.0.1";
 private const string CoverallsTool = "#tool nuget:?package=coveralls.io&version=1.3.4";
 private const string GitReleaseManagerTool = "#tool nuget:?package=gitreleasemanager&version=0.5.0";
 private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.2";
-private const string ReSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2017.1.20170428.83814";
+private const string ReSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2017.2.0";
 private const string ReSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.2.0";
 private const string KuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.3.1";
 private const string WyamTool = "#tool nuget:?package=Wyam&version=0.17.7";


### PR DESCRIPTION
Fixes #145 - DupFinder and InspectCode tasks for not recognise V15.3 of Visual Studio and give warnings in log.