### PR TITLE
Adding support for transifex

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -13,6 +13,7 @@
 #addin nuget:?package=Cake.MicrosoftTeams&version=0.3.0
 #addin nuget:?package=Cake.ReSharperReports&version=0.6.0
 #addin nuget:?package=Cake.Slack&version=0.6.0
+#addin nuget:?package=Cake.Transifex&Version=0.4.0
 #addin nuget:?package=Cake.Twitter&version=0.4.0
 #addin nuget:?package=Cake.Wyam&version=1.0.0
 

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -450,6 +450,10 @@ public class Builder
 
         if (!isDotNetCoreBuild)
         {
+            if (BuildParameters.TransifexEnabled)
+            {
+                BuildParameters.Tasks.BuildTask.IsDependentOn("Transifex-Pull-Translations");
+            }
             BuildParameters.Tasks.TestTask.IsDependentOn("Test-NUnit");
             BuildParameters.Tasks.TestTask.IsDependentOn("Test-xUnit");
             BuildParameters.Tasks.TestTask.IsDependentOn("Test-MSTest");
@@ -459,6 +463,10 @@ public class Builder
         }
         else
         {
+            if (BuildParameters.TransifexEnabled)
+            {
+                BuildParameters.Tasks.DotNetCoreBuildTask.IsDependentOn("Transifex-Pull-Translations");
+            }
             BuildParameters.Tasks.TestTask.IsDependentOn(prefix + "Test");
             BuildParameters.Tasks.InstallOpenCoverTask.IsDependentOn("Install-ReportGenerator");
             BuildParameters.Tasks.PackageTask.IsDependentOn(prefix + "Pack");

--- a/Cake.Recipe/Content/credentials.cake
+++ b/Cake.Recipe/Content/credentials.cake
@@ -122,6 +122,19 @@ public class CoverallsCredentials
     }
 }
 
+public class TransifexCredentials : AppVeyorCredentials
+{
+    public bool HasCredentials
+    {
+        get { return !string.IsNullOrEmpty(ApiToken); }
+    }
+
+    public TransifexCredentials(string apiToken)
+        : base(apiToken)
+    {
+    }
+}
+
 public class WyamCredentials
 {
     public string AccessToken { get; private set; }
@@ -209,6 +222,13 @@ public static CoverallsCredentials GetCoverallsCredentials(ICakeContext context)
 {
     return new CoverallsCredentials(
         context.EnvironmentVariable(Environment.CoverallsRepoTokenVariable));
+}
+
+public static TransifexCredentials GetTransifexCredentials(ICakeContext context)
+{
+    return new TransifexCredentials(
+        context.EnvironmentVariable(Environment.TransifexApiTokenVariable)
+    );
 }
 
 public static WyamCredentials GetWyamCredentials(ICakeContext context)

--- a/Cake.Recipe/Content/environment.cake
+++ b/Cake.Recipe/Content/environment.cake
@@ -20,6 +20,7 @@ public static class Environment
     public static string CodecovRepoTokenVariable { get; private set; }
     public static string CoverallsRepoTokenVariable { get; private set; }
     public static string MicrosoftTeamsWebHookUrlVariable { get; private set; }
+    public static string TransifexApiTokenVariable { get; private set; }
     public static string WyamAccessTokenVariable { get; private set; }
     public static string WyamDeployRemoteVariable { get; private set; }
     public static string WyamDeployBranchVariable { get; private set; }
@@ -45,6 +46,7 @@ public static class Environment
         string codecovRepoTokenVariable = null,
         string coverallsRepoTokenVariable = null,
         string microsoftTeamsWebHookUrlVariable = null,
+        string transifexApiTokenVariable = null,
         string wyamAccessTokenVariable = null,
         string wyamDeployRemoteVariable = null,
         string wyamDeployBranchVariable = null)
@@ -69,6 +71,7 @@ public static class Environment
         CodecovRepoTokenVariable = codecovRepoTokenVariable ?? "CODECOV_REPO_TOKEN";
         CoverallsRepoTokenVariable = coverallsRepoTokenVariable ?? "COVERALLS_REPO_TOKEN";
         MicrosoftTeamsWebHookUrlVariable = microsoftTeamsWebHookUrlVariable ?? "MICROSOFTTEAMS_WEBHOOKURL";
+        TransifexApiTokenVariable = transifexApiTokenVariable ?? "TRANSIFEX_API_TOKEN";
         WyamAccessTokenVariable = wyamAccessTokenVariable ?? "WYAM_ACCESS_TOKEN";
         WyamDeployRemoteVariable = wyamDeployRemoteVariable ?? "WYAM_DEPLOY_REMOTE";
         WyamDeployBranchVariable = wyamDeployBranchVariable ?? "WYAM_DEPLOY_BRANCH";

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -18,6 +18,7 @@ public static class BuildParameters
     public static bool IsReleaseBuild { get; private set; }
     public static bool IsDotNetCoreBuild { get; set; }
     public static bool IsNuGetBuild { get; set; }
+    public static bool TransifexEnabled { get; set; }
     public static GitHubCredentials GitHub { get; private set; }
     public static MicrosoftTeamsCredentials MicrosoftTeams { get; private set; }
     public static GitterCredentials Gitter { get; private set; }
@@ -29,6 +30,7 @@ public static class BuildParameters
     public static AppVeyorCredentials AppVeyor { get; private set; }
     public static CodecovCredentials Codecov { get; private set; }
     public static CoverallsCredentials Coveralls { get; private set; }
+    public static TransifexCredentials Transifex { get; private set; }
     public static WyamCredentials Wyam { get; private set; }
     public static BuildVersion Version { get; private set; }
     public static BuildPaths Paths { get; private set; }
@@ -236,6 +238,7 @@ public static class BuildParameters
         context.Information("IsRunningOnAppVeyor: {0}", IsRunningOnAppVeyor);
         context.Information("RepositoryOwner: {0}", RepositoryOwner);
         context.Information("RepositoryName: {0}", RepositoryName);
+        context.Information("TransifexEnabled: {0}", TransifexEnabled);
         context.Information("WyamRootDirectoryPath: {0}", WyamRootDirectoryPath);
         context.Information("WyamPublishDirectoryPath: {0}", WyamPublishDirectoryPath);
         context.Information("WyamConfigurationFile: {0}", WyamConfigurationFile);
@@ -290,6 +293,7 @@ public static class BuildParameters
         bool shouldRunDotNetCorePack = false,
         bool shouldBuildNugetSourcePackage = false,
         bool shouldRunIntegrationTests = false,
+        bool? transifexEnabled = null,
         DirectoryPath wyamRootDirectoryPath = null,
         DirectoryPath wyamPublishDirectoryPath = null,
         FilePath wyamConfigurationFile = null,
@@ -323,6 +327,8 @@ public static class BuildParameters
         RepositoryName = repositoryName ?? Title;
         AppVeyorAccountName = appVeyorAccountName ?? RepositoryOwner.Replace("-", "").ToLower();
         AppVeyorProjectSlug = appVeyorProjectSlug ?? Title.Replace(".", "-").ToLower();
+
+        TransifexEnabled = transifexEnabled ?? TransifexIsConfiguredForRepository();
 
         WyamRootDirectoryPath = wyamRootDirectoryPath ?? context.MakeAbsolute(context.Directory("docs"));
         WyamPublishDirectoryPath = wyamPublishDirectoryPath ?? context.MakeAbsolute(context.Directory("BuildArtifacts/temp/_PublishedDocumentation"));

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -49,6 +49,9 @@ public static class BuildParameters
     public static string AppVeyorAccountName { get; private set; }
     public static string AppVeyorProjectSlug { get; private set; }
 
+    public static TransifexMode TransifexPullMode { get; private set; }
+    public static int TransifexPullPercentage { get; private set; }
+
     public static bool ShouldBuildNugetSourcePackage { get; private set; }
     public static bool ShouldPostToGitter { get; private set; }
     public static bool ShouldPostToSlack { get; private set; }
@@ -239,6 +242,11 @@ public static class BuildParameters
         context.Information("RepositoryOwner: {0}", RepositoryOwner);
         context.Information("RepositoryName: {0}", RepositoryName);
         context.Information("TransifexEnabled: {0}", TransifexEnabled);
+        if (TransifexEnabled)
+        {
+            context.Information("TransifexPullMode: {0}", TransifexPullMode);
+            context.Information("TransifexPullPercentage: {0}", TransifexPullPercentage);
+        }
         context.Information("WyamRootDirectoryPath: {0}", WyamRootDirectoryPath);
         context.Information("WyamPublishDirectoryPath: {0}", WyamPublishDirectoryPath);
         context.Information("WyamConfigurationFile: {0}", WyamConfigurationFile);
@@ -294,6 +302,8 @@ public static class BuildParameters
         bool shouldBuildNugetSourcePackage = false,
         bool shouldRunIntegrationTests = false,
         bool? transifexEnabled = null,
+        TransifexMode transifexPullMode = TransifexMode.OnlyTranslated,
+        int transifexPullPercentage = 60,
         DirectoryPath wyamRootDirectoryPath = null,
         DirectoryPath wyamPublishDirectoryPath = null,
         FilePath wyamConfigurationFile = null,
@@ -329,6 +339,8 @@ public static class BuildParameters
         AppVeyorProjectSlug = appVeyorProjectSlug ?? Title.Replace(".", "-").ToLower();
 
         TransifexEnabled = transifexEnabled ?? TransifexIsConfiguredForRepository();
+        TransifexPullMode = transifexPullMode;
+        TransifexPullPercentage = transifexPullPercentage;
 
         WyamRootDirectoryPath = wyamRootDirectoryPath ?? context.MakeAbsolute(context.Directory("docs"));
         WyamPublishDirectoryPath = wyamPublishDirectoryPath ?? context.MakeAbsolute(context.Directory("BuildArtifacts/temp/_PublishedDocumentation"));

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -41,6 +41,7 @@ public class BuildTasks
     public CakeTaskBuilder<ActionTask> TestMSTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> TestVSTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> TestFixieTask { get; set; }
+    public CakeTaskBuilder<ActionTask> TransifexSetupTask { get; set; }
     public CakeTaskBuilder<ActionTask> DotNetCoreTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> IntegrationTestTask { get;set; }
     public CakeTaskBuilder<ActionTask> TestTask { get; set; }

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -43,6 +43,7 @@ public class BuildTasks
     public CakeTaskBuilder<ActionTask> TestFixieTask { get; set; }
     public CakeTaskBuilder<ActionTask> TransifexPullTranslations { get; set; }
     public CakeTaskBuilder<ActionTask> TransifexPushSourceResource { get; set; }
+    public CakeTaskBuilder<ActionTask> TransifexPushTranslations { get; set; }
     public CakeTaskBuilder<ActionTask> TransifexSetupTask { get; set; }
     public CakeTaskBuilder<ActionTask> DotNetCoreTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> IntegrationTestTask { get;set; }

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -41,6 +41,7 @@ public class BuildTasks
     public CakeTaskBuilder<ActionTask> TestMSTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> TestVSTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> TestFixieTask { get; set; }
+    public CakeTaskBuilder<ActionTask> TransifexPullTranslations { get; set; }
     public CakeTaskBuilder<ActionTask> TransifexPushSourceResource { get; set; }
     public CakeTaskBuilder<ActionTask> TransifexSetupTask { get; set; }
     public CakeTaskBuilder<ActionTask> DotNetCoreTestTask { get; set; }

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -41,6 +41,7 @@ public class BuildTasks
     public CakeTaskBuilder<ActionTask> TestMSTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> TestVSTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> TestFixieTask { get; set; }
+    public CakeTaskBuilder<ActionTask> TransifexPushSourceResource { get; set; }
     public CakeTaskBuilder<ActionTask> TransifexSetupTask { get; set; }
     public CakeTaskBuilder<ActionTask> DotNetCoreTestTask { get; set; }
     public CakeTaskBuilder<ActionTask> IntegrationTestTask { get;set; }

--- a/Cake.Recipe/Content/transifex.cake
+++ b/Cake.Recipe/Content/transifex.cake
@@ -54,3 +54,11 @@ BuildTasks.TransifexPullTranslations = Task("Transifex-Pull-Translations")
             MinimumPercentage = BuildParameters.TransifexPullPercentage
         });
     });
+
+BuildTasks.TransifexPushTranslations = Task("Transifex-Push-Translations")
+    .Does(() =>
+    {
+        TransifexPush(new TransifexPushSettings {
+            UploadTranslations = true
+        });
+    });

--- a/Cake.Recipe/Content/transifex.cake
+++ b/Cake.Recipe/Content/transifex.cake
@@ -30,3 +30,15 @@ BuildTasks.TransifexSetupTask = Task("Transifex-Setup")
         const string text = "[https://www.transifex.com]\r\nhostname = https://www.transifex.com\r\npassword = " + BuildParameters.Transifex.ApiToken + "\r\nusername = api";
         System.IO.File.WriteAllText(path, text, encoding);
     });
+
+BuildTasks.TransifexPushSourceResource = Task("Transifex-Push-SourceFiles")
+    .WithCriteria(() => BuildParameters.TransifexEnabled)
+    .WithCriteria(() => BuildParameters.IsRunningOnAppveyor || string.Equals(BuildParameters.Target, "Transifex-Push-SourceFiles", StringComparison.OrdinalIgnoreCase))
+    .IsDependentOn("Transifex-Setup")
+    .Does(() =>
+    {
+        // TODO: Allow the usage of force, perhaps when target have been explicitly called.
+        TransifexPush(new TransifexPushSettings {
+            UploadSourceFiles = true
+        });
+    });

--- a/Cake.Recipe/Content/transifex.cake
+++ b/Cake.Recipe/Content/transifex.cake
@@ -42,3 +42,15 @@ BuildTasks.TransifexPushSourceResource = Task("Transifex-Push-SourceFiles")
             Force = string.Equals(BuildParameters.Target, "Transifex-Push-SourceFiles", StringComparison.OrdinalIgnoreCase)
         });
     });
+
+BuildTasks.TransifexPullTranslations = Task("Transifex-Pull-Translations")
+    .WithCriteria(() => BuildParameters.TransifexEnabled)
+    .IsDependentOn("Transifex-Push-SourceFiles")
+    .Does(() =>
+    {
+        TransifexPull(new TransifexPullSettings {
+            All = true,
+            Mode = BuildParameters.TransifexPullMode,
+            MinimumPercentage = BuildParameters.TransifexPullPercentage
+        });
+    });

--- a/Cake.Recipe/Content/transifex.cake
+++ b/Cake.Recipe/Content/transifex.cake
@@ -1,0 +1,32 @@
+public static bool TransifexUserSettingsExists()
+{
+    var path = GetTransifexUserSettingsPath();
+    return FileExists(path);
+}
+
+public static string GetTransifexUserSettingsPath()
+{
+    var path = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments) + "/.transifexrc");
+    return path;
+}
+
+public static bool TransifexIsConfiguredForRepository()
+{
+    return FileExists("./.tx/config");
+}
+
+// Before we do anything with transifex, we must make sure that it have been properly
+// Initialized, this is mostly related to running on appveyor or other CI.
+// Because we expect the repository to already be configured to use
+// transifex, we cannot run tx init, or it would replace the repository configuration file.
+BuildTasks.TransifexSetupTask = Task("Transifex-Setup")
+    .WithCriteria(() => BuildParameters.TransifexEnabled)
+    .WithCriteria(() => !TransifexUserSettingsExists())
+    .WithCriteria(() => BuildParameters.Transifex.HasCredentials)
+    .Does(() =>
+    {
+        var path = GetTransifexUserSettingsPath();
+        var encoding = new System.Text.UTF8Encoding(false);
+        const string text = "[https://www.transifex.com]\r\nhostname = https://www.transifex.com\r\npassword = " + BuildParameters.Transifex.ApiToken + "\r\nusername = api";
+        System.IO.File.WriteAllText(path, text, encoding);
+    });

--- a/Cake.Recipe/Content/transifex.cake
+++ b/Cake.Recipe/Content/transifex.cake
@@ -19,7 +19,7 @@ public static bool TransifexIsConfiguredForRepository()
 // Initialized, this is mostly related to running on appveyor or other CI.
 // Because we expect the repository to already be configured to use
 // transifex, we cannot run tx init, or it would replace the repository configuration file.
-BuildTasks.TransifexSetupTask = Task("Transifex-Setup")
+BuildParameters.Tasks.TransifexSetupTask = Task("Transifex-Setup")
     .WithCriteria(() => BuildParameters.TransifexEnabled)
     .WithCriteria(() => !TransifexUserSettingsExists())
     .WithCriteria(() => BuildParameters.Transifex.HasCredentials)
@@ -31,7 +31,7 @@ BuildTasks.TransifexSetupTask = Task("Transifex-Setup")
         System.IO.File.WriteAllText(path, text, encoding);
     });
 
-BuildTasks.TransifexPushSourceResource = Task("Transifex-Push-SourceFiles")
+BuildParameters.Tasks.TransifexPushSourceResource = Task("Transifex-Push-SourceFiles")
     .WithCriteria(() => BuildParameters.TransifexEnabled)
     .WithCriteria(() => BuildParameters.IsRunningOnAppveyor || string.Equals(BuildParameters.Target, "Transifex-Push-SourceFiles", StringComparison.OrdinalIgnoreCase))
     .IsDependentOn("Transifex-Setup")
@@ -43,7 +43,7 @@ BuildTasks.TransifexPushSourceResource = Task("Transifex-Push-SourceFiles")
         });
     });
 
-BuildTasks.TransifexPullTranslations = Task("Transifex-Pull-Translations")
+BuildParameters.Tasks.TransifexPullTranslations = Task("Transifex-Pull-Translations")
     .WithCriteria(() => BuildParameters.TransifexEnabled)
     .IsDependentOn("Transifex-Push-SourceFiles")
     .Does(() =>
@@ -55,7 +55,7 @@ BuildTasks.TransifexPullTranslations = Task("Transifex-Pull-Translations")
         });
     });
 
-BuildTasks.TransifexPushTranslations = Task("Transifex-Push-Translations")
+BuildParameters.Tasks.TransifexPushTranslations = Task("Transifex-Push-Translations")
     .Does(() =>
     {
         TransifexPush(new TransifexPushSettings {

--- a/Cake.Recipe/Content/transifex.cake
+++ b/Cake.Recipe/Content/transifex.cake
@@ -37,8 +37,8 @@ BuildTasks.TransifexPushSourceResource = Task("Transifex-Push-SourceFiles")
     .IsDependentOn("Transifex-Setup")
     .Does(() =>
     {
-        // TODO: Allow the usage of force, perhaps when target have been explicitly called.
         TransifexPush(new TransifexPushSettings {
-            UploadSourceFiles = true
+            UploadSourceFiles = true,
+            Force = string.Equals(BuildParameters.Target, "Transifex-Push-SourceFiles", StringComparison.OrdinalIgnoreCase)
         });
     });


### PR DESCRIPTION
Moved from the issue:

**TASKS**

- [x] `Transifex-Setup`
  - Will only be run if the following conditions are met
    - Transifex support have been enabled explicitly, or implicitly if the following file exists in the repo `./.tx/config`
    - A user settings file doesn't already exists (this will always be located in `%USERPROFILE%\.transifexrc` on windows, don't know on other platforms)
    - If the transifex api credentials exists (by default will grab from the following environment variable `TRANSIFEX_API_TOKEN`)
  - Will have no dependencies
  - When it runs, it will create the user settings profile storing the specified api token.
- [x] `Transifex-Push-Sourcefiles`
  - Will run if Transifex support have been enabled explicitly, or implicitly, and only if running on appveyor (or called explicitly)
  - Will not check if the user settings file exists, if it doesn't the user will prompted for their username and password (transifex cli is responsible for that).
  - Will depend on `Transifex-Setup`
  - When running it will push all source files (think of the source `.resx` file) that have been configured for the repository.
- [x] `Transifex-Pull-Translations`
  - Will run if Transifex support have been enabled explicitly, or implicitly.
  - Will depend on `Transifex-Push-Sourcefiles` (*still a little unsure about this*)
  - When running it will pull in all translations from transifex (*still thinking if which parameters that should be configurable*)
- [x] `Transifex-Push-Translations`
  - Will not be run during normal build, but only when being explicitly called.
  - Won't have any dependencies at all
  - Won't have any criteria, if explicitly called, we expect the user knows what he/she does.
  - When running it will push all translations located in the local repository to transifex.
  - This is a function that shouldn't be used normally, especially since I don't know exactly who can push to transifex (I think only those that have full access.)
- [x] The build task will only take a dependency on `Transifex-Pull-translations` when transifex support have been enabled, otherwise they will remain as loose tasks.

**Requires**
The transifex client will be needed to be installed on the users computer, or the ci (available through pip as `transifex-client`, or on chocolatey with the same name (just pushed that package now)).

Will also require my own `Cake.Transifex` library, but still not completely sure what best way to include it.

will absolutely fix #127 