### PR TITLE
Fixed a few build errors that happened after including transifex support

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -338,7 +338,7 @@ public static class BuildParameters
         AppVeyorAccountName = appVeyorAccountName ?? RepositoryOwner.Replace("-", "").ToLower();
         AppVeyorProjectSlug = appVeyorProjectSlug ?? Title.Replace(".", "-").ToLower();
 
-        TransifexEnabled = transifexEnabled ?? TransifexIsConfiguredForRepository();
+        TransifexEnabled = transifexEnabled ?? TransifexIsConfiguredForRepository(context);
         TransifexPullMode = transifexPullMode;
         TransifexPullPercentage = transifexPullPercentage;
 
@@ -422,6 +422,7 @@ public static class BuildParameters
         AppVeyor = GetAppVeyorCredentials(context);
         Codecov = GetCodecovCredentials(context);
         Coveralls = GetCoverallsCredentials(context);
+        Transifex = GetTransifexCredentials(context);
         Wyam = GetWyamCredentials(context);
         IsPublishBuild = new [] {
             "Create-Release-Notes"

--- a/Cake.Recipe/Content/transifex.cake
+++ b/Cake.Recipe/Content/transifex.cake
@@ -1,18 +1,18 @@
-public static bool TransifexUserSettingsExists()
+public static bool TransifexUserSettingsExists(ICakeContext context)
 {
     var path = GetTransifexUserSettingsPath();
-    return FileExists(path);
+    return context.FileExists(path);
 }
 
 public static string GetTransifexUserSettingsPath()
 {
-    var path = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments) + "/.transifexrc");
+    var path = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments) + "/.transifexrc");
     return path;
 }
 
-public static bool TransifexIsConfiguredForRepository()
+public static bool TransifexIsConfiguredForRepository(ICakeContext context)
 {
-    return FileExists("./.tx/config");
+    return context.FileExists("./.tx/config");
 }
 
 // Before we do anything with transifex, we must make sure that it have been properly
@@ -21,19 +21,19 @@ public static bool TransifexIsConfiguredForRepository()
 // transifex, we cannot run tx init, or it would replace the repository configuration file.
 BuildParameters.Tasks.TransifexSetupTask = Task("Transifex-Setup")
     .WithCriteria(() => BuildParameters.TransifexEnabled)
-    .WithCriteria(() => !TransifexUserSettingsExists())
+    .WithCriteria(() => !TransifexUserSettingsExists(Context))
     .WithCriteria(() => BuildParameters.Transifex.HasCredentials)
     .Does(() =>
     {
         var path = GetTransifexUserSettingsPath();
         var encoding = new System.Text.UTF8Encoding(false);
-        const string text = "[https://www.transifex.com]\r\nhostname = https://www.transifex.com\r\npassword = " + BuildParameters.Transifex.ApiToken + "\r\nusername = api";
+        var text = "[https://www.transifex.com]\r\nhostname = https://www.transifex.com\r\npassword = " + BuildParameters.Transifex.ApiToken + "\r\nusername = api";
         System.IO.File.WriteAllText(path, text, encoding);
     });
 
 BuildParameters.Tasks.TransifexPushSourceResource = Task("Transifex-Push-SourceFiles")
     .WithCriteria(() => BuildParameters.TransifexEnabled)
-    .WithCriteria(() => BuildParameters.IsRunningOnAppveyor || string.Equals(BuildParameters.Target, "Transifex-Push-SourceFiles", StringComparison.OrdinalIgnoreCase))
+    .WithCriteria(() => BuildParameters.IsRunningOnAppVeyor || string.Equals(BuildParameters.Target, "Transifex-Push-SourceFiles", StringComparison.OrdinalIgnoreCase))
     .IsDependentOn("Transifex-Setup")
     .Does(() =>
     {


### PR DESCRIPTION
This commit fixes the following:
Using an alias in methods where 'Context' isn't automatically available.
Missing Namespace for System.IO.Path.
Using a const variable when it isn't possible in that context.

@gep13 this is quite the priority, as Cake.Recipe won't compile at all until this is merged.