### PR TITLE
Improve default coverage filter

### DIFF
--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -34,7 +34,7 @@ public static class ToolSettings
         DupFinderExcludeFilesByStartingCommentSubstring = dupFinderExcludeFilesByStartingCommentSubstring;
         DupFinderDiscardCost = dupFinderDiscardCost;
         DupFinderThrowExceptionOnFindingDuplicates = dupFinderThrowExceptionOnFindingDuplicates;
-        TestCoverageFilter = testCoverageFilter ?? "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]*";
+        TestCoverageFilter = testCoverageFilter ?? string.Format("+[{0}*]* -[*.Tests]*", BuildParameters.Title);
         TestCoverageExcludeByAttribute = testCoverageExcludeByAttribute ?? "*.ExcludeFromCodeCoverage*";
         TestCoverageExcludeByFile = testCoverageExcludeByFile ?? "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs";
         BuildPlatformTarget = buildPlatformTarget ?? PlatformTarget.MSIL;


### PR DESCRIPTION
The current coverage filter includes everything `+[*]*` and then selectively excludes some namespaces such as `-[xunit.*]*` and `-[Cake.Core]*`. This can results in some namespaces to be inadvertently included because they haven't been specifically excluded.

A much better default value would be to include only the desired namespace and exclude unit tests. Like so: `+[MyCakeAddin*]* -[*.Tests]*`.

As a side effect, this new filter ensures that namespaces from 3rd party nuget packages (such as moq just to name one example) are not included, which is the root of the issue I discuss in #160. 