### PR TITLE
More sensible default dupFinder exclude pattern

### DIFF
--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -29,8 +29,13 @@ public static class ToolSettings
     {
         context.Information("Setting up tools...");
 
-        // TODO: Remove hard coding of Cake.Example.Tests
-        DupFinderExcludePattern = dupFinderExcludePattern ?? new string[] { context.MakeAbsolute(context.Environment.WorkingDirectory) + "/src/Cake.Example.Tests/*.cs" };
+        var absoluteWorkingDirectory = context.MakeAbsolute(context.Environment.WorkingDirectory);
+        DupFinderExcludePattern = dupFinderExcludePattern ??
+            new string[]
+            {
+                string.Format("{0}/Source/{1}.Tests/**/*.cs", absoluteWorkingDirectory, BuildParameters.Title),
+                string.Format("{0}/Source/{1}/**/*.AssemblyInfo.cs", absoluteWorkingDirectory, BuildParameters.Title)
+            };
         DupFinderExcludeFilesByStartingCommentSubstring = dupFinderExcludeFilesByStartingCommentSubstring;
         DupFinderDiscardCost = dupFinderDiscardCost;
         DupFinderThrowExceptionOnFindingDuplicates = dupFinderThrowExceptionOnFindingDuplicates;

--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -29,12 +29,13 @@ public static class ToolSettings
     {
         context.Information("Setting up tools...");
 
-        var absoluteWorkingDirectory = context.MakeAbsolute(context.Environment.WorkingDirectory);
+        var absoluteTestDirectory = context.MakeAbsolute(BuildParameters.TestDirectoryPath);
+        var absoluteSourceDirectory = context.MakeAbsolute(BuildParameters.SolutionDirectoryPath);
         DupFinderExcludePattern = dupFinderExcludePattern ??
             new string[]
             {
-                string.Format("{0}/Source/{1}.Tests/**/*.cs", absoluteWorkingDirectory, BuildParameters.Title),
-                string.Format("{0}/Source/{1}/**/*.AssemblyInfo.cs", absoluteWorkingDirectory, BuildParameters.Title)
+                string.Format("{0}/{1}.Tests/**/*.cs", absoluteTestDirectory, BuildParameters.Title),
+                string.Format("{0}/**/*.AssemblyInfo.cs", absoluteSourceDirectory)
             };
         DupFinderExcludeFilesByStartingCommentSubstring = dupFinderExcludeFilesByStartingCommentSubstring;
         DupFinderDiscardCost = dupFinderDiscardCost;


### PR DESCRIPTION
Remove hard-coded "Cake.Example.Tests" and replace with a more sensible default dupFinder exclude pattern.

Resolves #174 