### PR TITLE
fix: don't include tools/*.csproj when packing

### DIFF
--- a/Cake.Recipe/Content/nuget.cake
+++ b/Cake.Recipe/Content/nuget.cake
@@ -4,6 +4,7 @@ BuildParameters.Tasks.DotNetCorePackTask = Task("DotNetCore-Pack")
     .Does(() =>
 {
     var projects = GetFiles(BuildParameters.SourceDirectoryPath + "/**/*.csproj")
+        - GetFiles(BuildParameters.SourceDirectoryPath + "/tools/**/*.csproj")
         - GetFiles(BuildParameters.SourceDirectoryPath + "/**/*.Tests.csproj");
 
     var msBuildSettings = new DotNetCoreMSBuildSettings()


### PR DESCRIPTION
resolves https://github.com/cake-contrib/Cake.Recipe/issues/210

nb: I totally did this PR in the GitHub web editor and haven't tested it but it should be fine ;-)

If you could ship a new release ASAP after merging that would be ace cause this problem is currently breaking the ecosystem. OpenCover started shipping sample projects as part of their package and we are now red build territory💥 