### PR TITLE
Fix casing inconsistency

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -13,7 +13,7 @@
 #addin nuget:?package=Cake.MicrosoftTeams&version=0.6.0
 #addin nuget:?package=Cake.ReSharperReports&version=0.8.0
 #addin nuget:?package=Cake.Slack&version=0.10.0
-#addin nuget:?package=Cake.Transifex&Version=0.4.0
+#addin nuget:?package=Cake.Transifex&version=0.4.0
 #addin nuget:?package=Cake.Twitter&version=0.6.0
 #addin nuget:?package=Cake.Wyam&version=1.2.0
 


### PR DESCRIPTION
I'm not sure if addin reference directives are case sensitive but to be safe, I'm correcting an inconsistency.

This is also important for the AddinDiscoverer which searches `.cake` files for addin references using a case-sensitive regex.