### PR TITLE
(GH-219) Create issue report with Cake.Issues

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -16,6 +16,11 @@
 #addin nuget:?package=Cake.Transifex&version=0.7.0
 #addin nuget:?package=Cake.Twitter&version=0.8.0
 #addin nuget:?package=Cake.Wyam&version=1.4.1
+#addin nuget:?package=Cake.Issues&version=0.3.1
+#addin nuget:?package=Cake.Issues.MsBuild&version=0.3.1
+#addin nuget:?package=Cake.Issues.InspectCode&version=0.3.0
+#addin nuget:?package=Cake.Issues.Reporting&version=0.3.0
+#addin nuget:?package=Cake.Issues.Reporting.Generic&version=0.3.4
 // Needed for Cake.Graph
 #addin nuget:?package=RazorEngine&version=3.10.0&loaddependencies=true
 

--- a/Cake.Recipe/Content/buildData.cake
+++ b/Cake.Recipe/Content/buildData.cake
@@ -1,0 +1,21 @@
+public class BuildData
+{
+	private readonly List<IIssue> issues = new List<IIssue>();
+
+	public IEnumerable<IIssue> Issues 
+	{ 
+		get
+		{
+			return issues.AsReadOnly();
+		} 
+	}
+
+	public BuildData()
+	{
+	}
+
+	public void AddIssues(IEnumerable<IIssue> issues)
+	{
+		this.issues.AddRange(issues);
+	}
+}


### PR DESCRIPTION
Create issue report with Cake.Issues.

Replace ReSharperReports for InspectCode with Cake.Issues report. Report also contains warnings from MsBuild (if not .NET Core build).

Changes behavior of report for InspectCode that it always is created instead of only in error case and that it won't be opened in browser.

In the future this can be enhanced with further features like optional build breaking based on certain condition, linting and reporting of issues in markdown files, etc.

The newly introduced `BuildData` class might also replace `BuildParameters` in the future.

Fixes #219 