### PR TITLE
Use absolute path for repository root

### DIFF
--- a/Cake.Recipe/Content/analyzing.cake
+++ b/Cake.Recipe/Content/analyzing.cake
@@ -98,7 +98,7 @@ BuildParameters.Tasks.InspectCodeTask = Task("InspectCode")
         var issues =
             ReadIssues(
                 InspectCodeIssuesFromFilePath(inspectCodeLogFilePath),
-                "./");
+                data.RepositoryRoot);
         Information("{0} InspectCode issues are found.", issues.Count());
         data.AddIssues(issues);
     })

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -35,7 +35,7 @@ Setup<BuildData>(context =>
         BuildMetaData.Version,
         BuildParameters.IsTagged);
 
-    return new BuildData();
+    return new BuildData(context);
 });
 
 Teardown(context =>
@@ -188,7 +188,7 @@ BuildParameters.Tasks.BuildTask = Task("Build")
                 MsBuildIssuesFromFilePath(
                     BuildParameters.Paths.Files.BuildLogFilePath,
                     MsBuildXmlFileLoggerFormat),
-                "./");
+                data.RepositoryRoot);
 
             Information("{0} MsBuild warnings are found.", issues.Count());
             data.AddIssues(issues);

--- a/Cake.Recipe/Content/buildData.cake
+++ b/Cake.Recipe/Content/buildData.cake
@@ -2,6 +2,8 @@ public class BuildData
 {
 	private readonly List<IIssue> issues = new List<IIssue>();
 
+	public DirectoryPath RepositoryRoot { get; }
+
 	public IEnumerable<IIssue> Issues 
 	{ 
 		get
@@ -10,8 +12,14 @@ public class BuildData
 		} 
 	}
 
-	public BuildData()
+	public BuildData(ICakeContext context)
 	{
+		if (context == null)
+		{
+			throw new ArgumentNullException(nameof(context));
+		}
+
+		RepositoryRoot = context.MakeAbsolute(context.Directory("./"));
 	}
 
 	public void AddIssues(IEnumerable<IIssue> issues)


### PR DESCRIPTION
Use absolute path for repository root which fixes exception during issue readin in some cases.

I've also used the `BuildData` typed context to hold the repository root path. Let me know if you prefer to have it in the BuildPaths class instead for consistency