### PR TITLE
Update to Cake.Issues 0.4.0

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -16,11 +16,11 @@
 #addin nuget:?package=Cake.Transifex&version=0.7.0
 #addin nuget:?package=Cake.Twitter&version=0.8.0
 #addin nuget:?package=Cake.Wyam&version=1.4.1
-#addin nuget:?package=Cake.Issues&version=0.3.1
-#addin nuget:?package=Cake.Issues.MsBuild&version=0.3.1
-#addin nuget:?package=Cake.Issues.InspectCode&version=0.3.0
-#addin nuget:?package=Cake.Issues.Reporting&version=0.3.0
-#addin nuget:?package=Cake.Issues.Reporting.Generic&version=0.3.4
+#addin nuget:?package=Cake.Issues&version=0.4.0
+#addin nuget:?package=Cake.Issues.MsBuild&version=0.4.0
+#addin nuget:?package=Cake.Issues.InspectCode&version=0.4.0
+#addin nuget:?package=Cake.Issues.Reporting&version=0.4.0
+#addin nuget:?package=Cake.Issues.Reporting.Generic&version=0.4.0
 // Needed for Cake.Graph
 #addin nuget:?package=RazorEngine&version=3.10.0&loaddependencies=true
 


### PR DESCRIPTION
Update to Cake.Issues 0.4.0. This brings reporting of the project name for InspectCode and also only project name, instead of full path, for MSBuild issues, improving filtering and sorting experience.