### PR TITLE
Update Cake.Git to 0.19.0 version

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -5,7 +5,7 @@
 #addin nuget:?package=Cake.Codecov&version=0.4.0
 #addin nuget:?package=Cake.Coveralls&version=0.9.0
 #addin nuget:?package=Cake.Figlet&version=1.1.0
-#addin nuget:?package=Cake.Git&version=0.18.0
+#addin nuget:?package=Cake.Git&version=0.19.0
 #addin nuget:?package=Cake.Gitter&version=0.9.0
 #addin nuget:?package=Cake.Graph&version=0.6.0
 #addin nuget:?package=Cake.Incubator&version=2.0.2


### PR DESCRIPTION
Cake.Git 0.19.0 is required to fix running Cake.Recipe with Cake.CoreCLR (https://github.com/cake-contrib/Cake_Git/issues/60)