### PR TITLE
Updated transifex translation pulling

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -274,8 +274,9 @@ public static class BuildParameters
     {
         get
         {
-            return BuildParameters.TransifexEnabled &&
-              (!BuildParameters.IsPullRequest || !BuildParameters.IsRunningOnAppVeyor);
+            return BuildParameters.TransifexEnabled && !BuildParameters.IsPullRequest
+                && (BuildParameters.IsRunningOnAppVeyor
+                    || string.Equals(BuildParameters.Target, "Transifex-Pull-Translations", StringComparison.OrdinalIgnoreCase));
         }
     }
 


### PR DESCRIPTION
Due to the transifex development team deciding to
require authentication when pulling translations
from their servers, it was required to update
the criteria for when to pull those translations.

This PR changes those criterias to match the criteria
used for the push Task.

reference issue #296 