### PR TITLE
Update GitVersion tool to 0.4.0 version

### DIFF
--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -5,7 +5,7 @@
 private const string CodecovTool = "#tool nuget:?package=codecov&version=1.1.0";
 private const string CoverallsTool = "#tool nuget:?package=coveralls.io&version=1.4.2";
 private const string GitReleaseManagerTool = "#tool nuget:?package=GitReleaseManager&version=0.8.0";
-private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.5";
+private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=4.0.0";
 private const string ReSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2018.2.3";
 private const string ReSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.4.0";
 private const string KuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.3.1";


### PR DESCRIPTION
#289

In 4.0.0 version new mode was introduced: [Mainline](https://gitversion.readthedocs.io/en/latest/reference/mainline-development/).
It would be nice to update GitVersion.CommandLine in Cake.Recipe to 4.0.0 to support this mode, which can be helpful for many open source libraries.