### PR TITLE
update to cake.incubator 4.0.2, Gitversion to 4.0.1-beta1-58

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -8,7 +8,7 @@
 #addin nuget:?package=Cake.Git&version=0.19.0
 #addin nuget:?package=Cake.Gitter&version=0.10.0
 #addin nuget:?package=Cake.Graph&version=0.6.0
-#addin nuget:?package=Cake.Incubator&version=3.1.0
+#addin nuget:?package=Cake.Incubator&version=4.0.2
 #addin nuget:?package=Cake.Kudu&version=0.8.0
 #addin nuget:?package=Cake.MicrosoftTeams&version=0.8.0
 #addin nuget:?package=Cake.ReSharperReports&version=0.10.0

--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -5,7 +5,7 @@
 private const string CodecovTool = "#tool nuget:?package=codecov&version=1.1.0";
 private const string CoverallsTool = "#tool nuget:?package=coveralls.io&version=1.4.2";
 private const string GitReleaseManagerTool = "#tool nuget:?package=GitReleaseManager&version=0.8.0";
-private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.5";
+private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=4.0.1-beta1-58";
 private const string ReSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2018.2.3";
 private const string ReSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.4.0";
 private const string KuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.3.1";


### PR DESCRIPTION
This PR is needed in order to be able to update to cake 0.33.0. As Cake.Recipe builds with Cake.Recipe we need to update some dependencies first. Another PR will follow