### PR TITLE
(GH-359) Disable task graphs in documentation by default

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -391,7 +391,7 @@ public static class BuildParameters
         bool shouldPublishChocolatey = true,
         bool shouldPublishNuGet = true,
         bool shouldPublishGitHub = true,
-        bool shouldDeployGraphDocumentation = true,
+        bool shouldDeployGraphDocumentation = false,
         bool shouldGenerateDocumentation = true,
         bool shouldExecuteGitLink = true,
         bool shouldRunDupFinder = true,

--- a/recipe.cake
+++ b/recipe.cake
@@ -9,7 +9,8 @@ BuildParameters.SetParameters(context: Context,
                             repositoryOwner: "cake-contrib",
                             repositoryName: "Cake.Recipe",
                             appVeyorAccountName: "cakecontrib",
-                            shouldRunGitVersion: true);
+                            shouldRunGitVersion: true,
+                            shouldDeployGraphDocumentation: true);
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
Disable task graphs in documentation by default.

Override default for Cake.Recipe build.

Fixes #359 