### PR TITLE
(GH-250) Added support to upload Cake.Issues report to appveyor

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -24,6 +24,10 @@
 // Needed for Cake.Graph
 #addin nuget:?package=RazorEngine&version=3.10.0&loaddependencies=true
 
+// TODO: Conditionally decide wether to install packages or not
+#addin nuget:?package=Cake.Issues.PullRequests&version=0.6.2
+#addin nuget:?package=Cake.Issues.PullRequests.AppVeyor&version=0.6.0
+
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));
     try

--- a/Cake.Recipe/Content/appveyor.cake
+++ b/Cake.Recipe/Content/appveyor.cake
@@ -34,6 +34,21 @@ BuildParameters.Tasks.PrintAppVeyorEnvironmentVariablesTask = Task("Print-AppVey
     Information("CONFIGURATION: {0}", EnvironmentVariable("CONFIGURATION"));
 });
 
+if (BuildSystem.IsRunningOnAppVeyor && !BuildParameters.IsNuGetBuild) {
+    BuildParameters.Tasks.ReportMessagesToCi = Task("Report-Messages-To-CI")
+        .IsDependentOn("InspectCode")
+        .IsDependeeOf("AppVeyor")
+        .WithCriteria<BuildData>((context, data) => data.Issues.Any(), "No issues to report.")
+        .Does<BuildData>((data) =>
+    {
+        ReportIssuesToPullRequest(
+            data.Issues,
+            AppVeyorBuilds(),
+            data.RepositoryRoot.FullPath
+        );
+    });
+}
+
 BuildParameters.Tasks.UploadAppVeyorArtifactsTask = Task("Upload-AppVeyor-Artifacts")
     .IsDependentOn("Package")
     .WithCriteria(() => BuildParameters.IsRunningOnAppVeyor)

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -55,4 +55,5 @@ public class BuildTasks
     public CakeTaskBuilder PublishDocumentationTask { get; set; }
     public CakeTaskBuilder PreviewDocumentationTask { get; set; }
     public CakeTaskBuilder ForcePublishDocumentationTask { get; set; }
+    public CakeTaskBuilder ReportMessagesToCi {get; set; }
 }


### PR DESCRIPTION
This PR adds support for uploading issues to appveyor that was created through `Cake.Issues`.

Test run:
Task: https://ci.appveyor.com/project/AdmiringWorm/cake-recipe/builds/24316246#L4456
Results: https://ci.appveyor.com/project/AdmiringWorm/cake-recipe/builds/24316246/messages

fixes #250 

/CC @pascalberger @gep13 