### PR TITLE
Customization of GitVersionTool version with "CustomGitVersionTool"

### DIFF
--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -5,7 +5,9 @@
 private const string CodecovTool = "#tool nuget:?package=codecov&version=1.4.0";
 private const string CoverallsTool = "#tool nuget:?package=coveralls.io&version=1.4.2";
 private const string GitReleaseManagerTool = "#tool nuget:?package=GitReleaseManager&version=0.8.0";
-private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.5";
+#if (!CustomGitVersionTool)
+    private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.5";
+#endif
 private const string ReSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2018.3.4";
 private const string ReSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.4.0";
 private const string KuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.5.2";


### PR DESCRIPTION
Following suggestion in: https://github.com/cake-contrib/Cake.Recipe/issues/214
I would like to make it possible to customize GitVersion, so I can use GitVersion 4.0.0 