### PR TITLE
Azure pipelines

### DIFF
--- a/Cake.Recipe/Content/analyzing.cake
+++ b/Cake.Recipe/Content/analyzing.cake
@@ -64,9 +64,9 @@ BuildParameters.Tasks.DupFinderTask = Task("DupFinder")
             BuildParameters.Paths.Directories.DupFinderTestResults.CombineWithFilePath("dupfinder.xml"),
             outputHtmlFile);
 
-        if(BuildParameters.IsRunningOnAppVeyor && FileExists(outputHtmlFile))
+        if(!BuildParameters.IsLocalBuild && FileExists(outputHtmlFile))
         {
-            AppVeyor.UploadArtifact(outputHtmlFile);
+            BuildParameters.BuildProvider.UploadArtifact(outputHtmlFile);
         }
 
         if(BuildParameters.IsLocalBuild)
@@ -114,9 +114,9 @@ BuildParameters.Tasks.InspectCodeTask = Task("CreateIssuesReport")
             "./",
             issueReportFile);
 
-        if(BuildParameters.IsRunningOnAppVeyor && FileExists(issueReportFile))
+        if(!BuildParameters.IsLocalBuild && FileExists(issueReportFile))
         {
-            AppVeyor.UploadArtifact(issueReportFile);
+            BuildParameters.BuildProvider.UploadArtifact(issueReportFile);
         }
     });
 

--- a/Cake.Recipe/Content/appveyor.cake
+++ b/Cake.Recipe/Content/appveyor.cake
@@ -108,10 +108,10 @@ public class AppVeyorBuildInfo : IBuildInfo
 {
     public AppVeyorBuildInfo(IAppVeyorProvider appVeyor)
     {
-        Number = appVeyor.Environment.Build.Number;
+        Number = appVeyor.Environment.Build.Number.ToString();
     }
 
-    public int Number { get; }    
+    public string Number { get; }    
 }
 
 public class AppVeyorBuildProvider : IBuildProvider

--- a/Cake.Recipe/Content/appveyor.cake
+++ b/Cake.Recipe/Content/appveyor.cake
@@ -75,7 +75,7 @@ public class AppVeyorTagInfo : ITagInfo
 
     public bool IsTag { get; }
 
-    public string Name { get; }    
+    public string Name { get; }
 }
 
 public class AppVeyorRepositoryInfo : IRepositoryInfo
@@ -101,7 +101,7 @@ public class AppVeyorPullRequestInfo : IPullRequestInfo
         IsPullRequest = appVeyor.Environment.PullRequest.IsPullRequest;
     }
 
-    public bool IsPullRequest { get; }    
+    public bool IsPullRequest { get; }
 }
 
 public class AppVeyorBuildInfo : IBuildInfo
@@ -111,7 +111,7 @@ public class AppVeyorBuildInfo : IBuildInfo
         Number = appVeyor.Environment.Build.Number.ToString();
     }
 
-    public string Number { get; }    
+    public string Number { get; }
 }
 
 public class AppVeyorBuildProvider : IBuildProvider

--- a/Cake.Recipe/Content/azurepipelines.cake
+++ b/Cake.Recipe/Content/azurepipelines.cake
@@ -81,6 +81,6 @@ public class AzurePipelinesBuildProvider : IBuildProvider
 
     public void UploadArtifact(FilePath file)
     {
-        _tfBuild.Commands.UploadArtifact("artifacts", file);    
+        _tfBuild.Commands.UploadArtifact("artifacts", file, file.GetFilename().FullPath);    
     }
 }

--- a/Cake.Recipe/Content/azurepipelines.cake
+++ b/Cake.Recipe/Content/azurepipelines.cake
@@ -1,0 +1,27 @@
+///////////////////////////////////////////////////////////////////////////////
+// BUILD PROVIDER
+///////////////////////////////////////////////////////////////////////////////
+
+public class AzurePipelinesBuildInfo : IBuildInfo
+{
+    public AzurePipelinesBuildInfo(ITFBuildProvider tfBuild)
+    {
+        Number = tfBuild.Environment.Build.Number;
+    }
+
+    public string Number { get; }
+}
+
+public class AzurePipelinesBuildProvider : IBuildProvider
+{
+    public AzurePipelinesBuildProvider(ITFBuildProvider tfBuild)
+    {
+        Build = new AzurePipelinesBuildInfo(tfBuild);
+    }
+
+    public IRepositoryInfo Repository { get; }
+
+    public IPullRequestInfo PullRequest { get; }
+
+    public IBuildInfo Build { get; }
+}

--- a/Cake.Recipe/Content/azurepipelines.cake
+++ b/Cake.Recipe/Content/azurepipelines.cake
@@ -67,6 +67,8 @@ public class AzurePipelinesBuildProvider : IBuildProvider
         Build = new AzurePipelinesBuildInfo(tfBuild);
         PullRequest = new AzurePipelinesPullRequestInfo(tfBuild, environment);
         Repository = new AzurePipelinesRepositoryInfo(tfBuild);
+
+        _tfBuild = tfBuild;
     }
 
     public IRepositoryInfo Repository { get; }
@@ -74,4 +76,11 @@ public class AzurePipelinesBuildProvider : IBuildProvider
     public IPullRequestInfo PullRequest { get; }
 
     public IBuildInfo Build { get; }
+
+    private readonly ITFBuildProvider _tfBuild;
+
+    public void UploadArtifact(FilePath file)
+    {
+        _tfBuild.Commands.UploadArtifact("artifacts", file);    
+    }
 }

--- a/Cake.Recipe/Content/azurepipelines.cake
+++ b/Cake.Recipe/Content/azurepipelines.cake
@@ -2,6 +2,49 @@
 // BUILD PROVIDER
 ///////////////////////////////////////////////////////////////////////////////
 
+public class AzurePipelinesTagInfo : ITagInfo
+{
+    public AzurePipelinesTagInfo(ITFBuildProvider tfBuild)
+    {
+        // at the moment, there is no ability to know is it tag or not
+        IsTag = tfBuild.Environment.Repository.Branch.StartsWith("refs/tags/");
+        Name = IsTag
+            ? tfBuild.Environment.Repository.Branch.Substring(10)
+            : string.Empty;
+    }
+
+    public bool IsTag { get; }
+
+    public string Name { get; }
+}
+
+public class AzurePipelinesRepositoryInfo : IRepositoryInfo
+{
+    public AzurePipelinesRepositoryInfo(ITFBuildProvider tfBuild)
+    {
+        Branch = tfBuild.Environment.Repository.Branch;
+        Name = tfBuild.Environment.Repository.RepoName;
+        Tag = new AzurePipelinesTagInfo(tfBuild);
+    }
+
+    public string Branch { get; }
+
+    public string Name { get; }
+
+    public ITagInfo Tag { get; }
+}
+
+public class AzurePipelinesPullRequestInfo : IPullRequestInfo
+{
+    public AzurePipelinesPullRequestInfo(ITFBuildProvider tfBuild)
+    {
+        //todo: update to `tfBuild.Environment.PullRequest.IsPullRequest` after upgrade to 0.33.0
+        IsPullRequest = false;
+    }
+
+    public bool IsPullRequest { get; }
+}
+
 public class AzurePipelinesBuildInfo : IBuildInfo
 {
     public AzurePipelinesBuildInfo(ITFBuildProvider tfBuild)
@@ -17,6 +60,8 @@ public class AzurePipelinesBuildProvider : IBuildProvider
     public AzurePipelinesBuildProvider(ITFBuildProvider tfBuild)
     {
         Build = new AzurePipelinesBuildInfo(tfBuild);
+        PullRequest = new AzurePipelinesPullRequestInfo(tfBuild);
+        Repository = new AzurePipelinesRepositoryInfo(tfBuild);
     }
 
     public IRepositoryInfo Repository { get; }

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -408,8 +408,23 @@ BuildParameters.Tasks.PackageTask = Task("Package")
 BuildParameters.Tasks.DefaultTask = Task("Default")
     .IsDependentOn("Package");
 
+BuildParameters.Tasks.UploadArtifactsTask = Task("Upload-Artifacts")
+    .IsDependentOn("Package")
+    .WithCriteria(() => !BuildParameters.IsLocalBuild)
+    .WithCriteria(() => DirectoryExists(BuildParameters.Paths.Directories.NuGetPackages) || DirectoryExists(BuildParameters.Paths.Directories.ChocolateyPackages))
+    .Does(() =>
+{
+    // Concatenating FilePathCollections should make sure we get unique FilePaths
+    foreach(var package in GetFiles(BuildParameters.Paths.Directories.Packages + "/**/*") +
+                           GetFiles(BuildParameters.Paths.Directories.NuGetPackages + "/*") +
+                           GetFiles(BuildParameters.Paths.Directories.ChocolateyPackages + "/*"))
+    {
+        BuildParameters.BuildProvider.UploadArtifact(package);
+    }
+});
+
 BuildParameters.Tasks.AppVeyorTask = Task("AppVeyor")
-    .IsDependentOn("Upload-AppVeyor-Artifacts")
+    .IsDependentOn("Upload-Artifacts")
     .IsDependentOn("Publish-MyGet-Packages")
     .IsDependentOn("Publish-Nuget-Packages")
     .IsDependentOn("Publish-GitHub-Release")

--- a/Cake.Recipe/Content/buildProvider.cake
+++ b/Cake.Recipe/Content/buildProvider.cake
@@ -21,7 +21,7 @@ public interface IPullRequestInfo
 
 public interface IBuildInfo
 {
-    int Number { get; }
+    string Number { get; }
 }
 
 public interface IBuildProvider
@@ -35,6 +35,12 @@ public interface IBuildProvider
 
 public static IBuildProvider GetBuildProvider(ICakeContext context, BuildSystem buildSystem)
 {
+    //todo: need to be replaced to `IsRunningOnAzurePipelines || IsRunningOnAzurePipelinesHosted` after update to Cake 0.33.0
+    if (buildSystem.IsRunningOnTFS || buildSystem.IsRunningOnVSTS)
+    {
+        return new AzurePipelinesBuildProvider(buildSystem.TFBuild);
+    }
+
     // always fallback to AppVeyor
     return new AppVeyorBuildProvider(buildSystem.AppVeyor);
 }

--- a/Cake.Recipe/Content/buildProvider.cake
+++ b/Cake.Recipe/Content/buildProvider.cake
@@ -31,6 +31,8 @@ public interface IBuildProvider
     IPullRequestInfo PullRequest { get; }
 
     IBuildInfo Build { get; }
+
+    void UploadArtifact(FilePath file);
 }
 
 public static IBuildProvider GetBuildProvider(ICakeContext context, BuildSystem buildSystem)

--- a/Cake.Recipe/Content/buildProvider.cake
+++ b/Cake.Recipe/Content/buildProvider.cake
@@ -38,7 +38,7 @@ public static IBuildProvider GetBuildProvider(ICakeContext context, BuildSystem 
     //todo: need to be replaced to `IsRunningOnAzurePipelines || IsRunningOnAzurePipelinesHosted` after update to Cake 0.33.0
     if (buildSystem.IsRunningOnTFS || buildSystem.IsRunningOnVSTS)
     {
-        return new AzurePipelinesBuildProvider(buildSystem.TFBuild);
+        return new AzurePipelinesBuildProvider(buildSystem.TFBuild, context.Environment);
     }
 
     // always fallback to AppVeyor

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -4,7 +4,7 @@ public class BuildTasks
     public CakeTaskBuilder InspectCodeTask { get; set; }
     public CakeTaskBuilder AnalyzeTask { get; set; }
     public CakeTaskBuilder PrintAppVeyorEnvironmentVariablesTask { get; set; }
-    public CakeTaskBuilder UploadAppVeyorArtifactsTask { get; set; }
+    public CakeTaskBuilder UploadArtifactsTask { get; set; }
     public CakeTaskBuilder ClearAppVeyorCacheTask { get; set; }
     public CakeTaskBuilder ShowInfoTask { get; set; }
     public CakeTaskBuilder CleanTask { get; set; }

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,37 +1,4 @@
-// todo: temporarily switch to local sources
-//#load nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&prerelease
-
-#load "Cake.Recipe/Content/addins.cake"
-#load "Cake.Recipe/Content/analyzing.cake"
-#load "Cake.Recipe/Content/appveyor.cake"
-#load "Cake.Recipe/Content/azurepipelines.cake"
-#load "Cake.Recipe/Content/build.cake"
-#load "Cake.Recipe/Content/buildData.cake"
-#load "Cake.Recipe/Content/buildProvider.cake"
-#load "Cake.Recipe/Content/chocolatey.cake"
-#load "Cake.Recipe/Content/codecov.cake"
-#load "Cake.Recipe/Content/configuration.cake"
-#load "Cake.Recipe/Content/coveralls.cake"
-#load "Cake.Recipe/Content/credentials.cake"
-#load "Cake.Recipe/Content/environment.cake"
-#load "Cake.Recipe/Content/gitlink.cake"
-#load "Cake.Recipe/Content/gitreleasemanager.cake"
-#load "Cake.Recipe/Content/gitter.cake"
-#load "Cake.Recipe/Content/gitversion.cake"
-#load "Cake.Recipe/Content/microsoftteams.cake"
-#load "Cake.Recipe/Content/nuget.cake"
-#load "Cake.Recipe/Content/packages.cake"
-#load "Cake.Recipe/Content/parameters.cake"
-#load "Cake.Recipe/Content/paths.cake"
-#load "Cake.Recipe/Content/slack.cake"
-#load "Cake.Recipe/Content/tasks.cake"
-#load "Cake.Recipe/Content/testing.cake"
-#load "Cake.Recipe/Content/tools.cake"
-#load "Cake.Recipe/Content/toolsettings.cake"
-#load "Cake.Recipe/Content/transifex.cake"
-#load "Cake.Recipe/Content/twitter.cake"
-#load "Cake.Recipe/Content/version.cake"
-#load "Cake.Recipe/Content/wyam.cake"
+#load nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&prerelease
 
 Environment.SetVariableNames();
 

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,37 @@
-#load nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&prerelease
+// todo: temporarily switch to local sources
+//#load nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&prerelease
+
+#load "Cake.Recipe/Content/addins.cake"
+#load "Cake.Recipe/Content/analyzing.cake"
+#load "Cake.Recipe/Content/appveyor.cake"
+#load "Cake.Recipe/Content/azurepipelines.cake"
+#load "Cake.Recipe/Content/build.cake"
+#load "Cake.Recipe/Content/buildData.cake"
+#load "Cake.Recipe/Content/buildProvider.cake"
+#load "Cake.Recipe/Content/chocolatey.cake"
+#load "Cake.Recipe/Content/codecov.cake"
+#load "Cake.Recipe/Content/configuration.cake"
+#load "Cake.Recipe/Content/coveralls.cake"
+#load "Cake.Recipe/Content/credentials.cake"
+#load "Cake.Recipe/Content/environment.cake"
+#load "Cake.Recipe/Content/gitlink.cake"
+#load "Cake.Recipe/Content/gitreleasemanager.cake"
+#load "Cake.Recipe/Content/gitter.cake"
+#load "Cake.Recipe/Content/gitversion.cake"
+#load "Cake.Recipe/Content/microsoftteams.cake"
+#load "Cake.Recipe/Content/nuget.cake"
+#load "Cake.Recipe/Content/packages.cake"
+#load "Cake.Recipe/Content/parameters.cake"
+#load "Cake.Recipe/Content/paths.cake"
+#load "Cake.Recipe/Content/slack.cake"
+#load "Cake.Recipe/Content/tasks.cake"
+#load "Cake.Recipe/Content/testing.cake"
+#load "Cake.Recipe/Content/tools.cake"
+#load "Cake.Recipe/Content/toolsettings.cake"
+#load "Cake.Recipe/Content/transifex.cake"
+#load "Cake.Recipe/Content/twitter.cake"
+#load "Cake.Recipe/Content/version.cake"
+#load "Cake.Recipe/Content/wyam.cake"
 
 Environment.SetVariableNames();
 


### PR DESCRIPTION
This PR adds support for running cake.recipe on AzurePipelines with all main features. (another part of #259)

Test run on AzurePipelines you can check [here](https://dev.azure.com/vadimhatsura/vadimgatsura/_build/results?buildId=99), which is built from [custom branch in fork](https://github.com/vhatsura/Cake.Recipe/pull/1)

Changes:

* type of `Number` property of `IBuildInfo` interface was changed from `int` to `string` (BuildNumber on AzurePipelines is string)
* `IBuildProvider` interface is extended by `UploadArtifact(FilePath file)` method
* there is implementation of `IBuildProvider` for AzurePipelines
* `UploadAppVeyorArtifactsTask` renamed to `UploadArtifactsTask` ("Upload-AppVeyor-Artifacts" -> "Upload-Artifacts")

Open questions:

* The main task for running on CI is called `AppVeyor`. I didn't rename it due to backward compatibility. What we need to do it with it, because if I want to run my cake on AzurePipelines with Cake.Recipe I need to call `AppVeyour` target, which is a litle bit confusing.