### PR TITLE
Updating Cake.Graph to version 0.8.0

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -7,7 +7,7 @@
 #addin nuget:?package=Cake.Figlet&version=1.2.0
 #addin nuget:?package=Cake.Git&version=0.19.0
 #addin nuget:?package=Cake.Gitter&version=0.10.0
-#addin nuget:?package=Cake.Graph&version=0.6.0
+#addin nuget:?package=Cake.Graph&version=0.8.0
 #addin nuget:?package=Cake.Incubator&version=3.1.0
 #addin nuget:?package=Cake.Kudu&version=0.8.0
 #addin nuget:?package=Cake.MicrosoftTeams&version=0.8.0
@@ -21,8 +21,6 @@
 #addin nuget:?package=Cake.Issues.InspectCode&version=0.6.1
 #addin nuget:?package=Cake.Issues.Reporting&version=0.6.1
 #addin nuget:?package=Cake.Issues.Reporting.Generic&version=0.6.2
-// Needed for Cake.Graph
-#addin nuget:?package=RazorEngine&version=3.10.0&loaddependencies=true
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));


### PR DESCRIPTION
Updating to the newest version that supports .NET Standard 2.0 and includes all the correct dependencies for the Razor view engine in the NuGet  so they no longer need manually added. Fixes #381 and #302 