### PR TITLE
(GH-470) Use Cake.Issues.Recipe for issue management

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -6,7 +6,6 @@
 #addin nuget:?package=Cake.Coveralls&version=0.10.1
 #addin nuget:?package=Cake.Email&version=0.9.1&loaddependencies=true // loading dependencies is important to ensure Cake.Email.Common is loaded as well
 #addin nuget:?package=Cake.Figlet&version=1.3.1
-#addin nuget:?package=Cake.Git&version=0.21.0
 #addin nuget:?package=Cake.Gitter&version=0.11.1
 #addin nuget:?package=Cake.Incubator&version=5.1.0
 #addin nuget:?package=Cake.Kudu&version=0.10.1
@@ -16,15 +15,8 @@
 #addin nuget:?package=Cake.Transifex&version=0.8.0
 #addin nuget:?package=Cake.Twitter&version=0.10.1
 #addin nuget:?package=Cake.Wyam&version=2.2.7
-#addin nuget:?package=Cake.Issues&version=0.7.1
-#addin nuget:?package=Cake.Issues.MsBuild&version=0.7.2
-#addin nuget:?package=Cake.Issues.InspectCode&version=0.7.1
-#addin nuget:?package=Cake.Issues.Reporting&version=0.7.0
-#addin nuget:?package=Cake.Issues.Reporting.Generic&version=0.7.2
 
-// TODO: Conditionally decide whether to install packages or not
-#addin nuget:?package=Cake.Issues.PullRequests&version=0.7.0
-#addin nuget:?package=Cake.Issues.PullRequests.AppVeyor&version=0.7.0
+#load nuget:?package=Cake.Issues.Recipe&version=0.3.0
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));

--- a/Cake.Recipe/Content/analyzing.cake
+++ b/Cake.Recipe/Content/analyzing.cake
@@ -94,34 +94,11 @@ BuildParameters.Tasks.InspectCodeTask = Task("InspectCode")
 
         InspectCode(BuildParameters.SolutionFilePath, settings);
 
-        // Parse issues.
-        var issues =
-            ReadIssues(
-                InspectCodeIssuesFromFilePath(inspectCodeLogFilePath),
-                data.RepositoryRoot);
-        Information("{0} InspectCode issues are found.", issues.Count());
-        data.AddIssues(issues);
+        // Pass path to InspectCode log file to Cake.Issues.Recipe
+        IssuesParameters.InputFiles.InspectCodeLogFilePath = inspectCodeLogFilePath;
     })
 );
 
-BuildParameters.Tasks.CreateIssuesReportTask = Task("CreateIssuesReport")
-    .IsDependentOn("InspectCode")
-    .Does<BuildData>(data => {
-        var issueReportFile = BuildParameters.Paths.Directories.TestResults.CombineWithFilePath("issues-report.html");
-
-        CreateIssueReport(
-            data.Issues,
-            GenericIssueReportFormatFromEmbeddedTemplate(GenericIssueReportTemplate.HtmlDxDataGrid),
-            "./",
-            issueReportFile);
-
-        if (!BuildParameters.IsLocalBuild && FileExists(issueReportFile))
-        {
-            BuildParameters.BuildProvider.UploadArtifact(issueReportFile);
-        }
-    });
-
 BuildParameters.Tasks.AnalyzeTask = Task("Analyze")
     .IsDependentOn("DupFinder")
-    .IsDependentOn("InspectCode")
-    .IsDependentOn("CreateIssuesReport");
+    .IsDependentOn("InspectCode");

--- a/Cake.Recipe/Content/appveyor.cake
+++ b/Cake.Recipe/Content/appveyor.cake
@@ -34,21 +34,6 @@ BuildParameters.Tasks.PrintAppVeyorEnvironmentVariablesTask = Task("Print-AppVey
     Information("CONFIGURATION: {0}", EnvironmentVariable("CONFIGURATION"));
 });
 
-if (BuildSystem.IsRunningOnAppVeyor && !BuildParameters.IsNuGetBuild) {
-    BuildParameters.Tasks.ReportMessagesToCi = Task("Report-Messages-To-CI")
-        .IsDependentOn("CreateIssuesReport")
-        .IsDependeeOf("ContinuousIntegration")
-        .WithCriteria<BuildData>((context, data) => data.Issues.Any(), "No issues to report.")
-        .Does<BuildData>((data) =>
-    {
-        ReportIssuesToPullRequest(
-            data.Issues,
-            AppVeyorBuilds(),
-            data.RepositoryRoot.FullPath
-        );
-    });
-}
-
 BuildParameters.Tasks.ClearAppVeyorCacheTask = Task("Clear-AppVeyor-Cache")
     .Does(() =>
         RequireAddin(@"#addin nuget:?package=Cake.AppVeyor&version=4.0.0&loaddependencies=true

--- a/Cake.Recipe/Content/buildData.cake
+++ b/Cake.Recipe/Content/buildData.cake
@@ -1,29 +1,10 @@
 public class BuildData
 {
-	private readonly List<IIssue> issues = new List<IIssue>();
-
-	public DirectoryPath RepositoryRoot { get; }
-
-	public IEnumerable<IIssue> Issues
-	{
-		get
-		{
-			return issues.AsReadOnly();
-		}
-	}
-
 	public BuildData(ICakeContext context)
 	{
 		if (context == null)
 		{
 			throw new ArgumentNullException(nameof(context));
 		}
-
-		RepositoryRoot = context.MakeAbsolute(context.Directory("./"));
-	}
-
-	public void AddIssues(IEnumerable<IIssue> issues)
-	{
-		this.issues.AddRange(issues);
 	}
 }

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -2,7 +2,6 @@ public class BuildTasks
 {
     public CakeTaskBuilder DupFinderTask { get; set; }
     public CakeTaskBuilder InspectCodeTask { get; set; }
-    public CakeTaskBuilder CreateIssuesReportTask { get; set; }
     public CakeTaskBuilder AnalyzeTask { get; set; }
     public CakeTaskBuilder PrintAppVeyorEnvironmentVariablesTask { get; set; }
     public CakeTaskBuilder UploadArtifactsTask { get; set; }


### PR DESCRIPTION
Replace issue management with [Cake.Issues.Recipe](https://cakeissues.net/docs/recipe/overview). This will bring integration with build servers (currently Azure Pipelines and AppVeyor) and pull request systems (currently Azure Repos).

`BuildData` class is now empty, but I kept it here since using it is part of #396.

Since Cake.Git already comes with Cake.Issues.Recipe it needs to be removed from Cake.Recipe.

Fixes #470 