### PR TITLE
(GH-356) Add support for generating coverage reports using coverlet

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -4,6 +4,7 @@
 
 #addin nuget:?package=Cake.Codecov&version=0.7.0
 #addin nuget:?package=Cake.Coveralls&version=0.10.1
+#addin nuget:?package=Cake.Coverlet&version=2.3.4
 #addin nuget:?package=Cake.Email&version=0.9.1&loaddependencies=true // loading dependencies is important to ensure Cake.Email.Common is loaded as well
 #addin nuget:?package=Cake.Figlet&version=1.3.1
 #addin nuget:?package=Cake.Gitter&version=0.11.1

--- a/Cake.Recipe/Content/codecov.cake
+++ b/Cake.Recipe/Content/codecov.cake
@@ -3,27 +3,35 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 BuildParameters.Tasks.UploadCodecovReportTask = Task("Upload-Codecov-Report")
-    .WithCriteria(() => FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath), "Skipping because no coverage report has been generated")
     .WithCriteria(() => BuildParameters.IsMainRepository, "Skipping because not running from the main repository")
     .WithCriteria(() => BuildParameters.ShouldRunCodecov, "Skipping because uploading to codecov is disabled")
     .WithCriteria(() => BuildParameters.CanPublishToCodecov, "Skipping because repo token is missing, or not running on appveyor")
     .Does(() => RequireTool(ToolSettings.CodecovTool, () => {
-        var settings = new CodecovSettings {
-            Files = new[] { BuildParameters.Paths.Files.TestCoverageOutputFilePath.ToString() },
-            Required = true
-        };
-        if (BuildParameters.Version != null &&
-            !string.IsNullOrEmpty(BuildParameters.Version.FullSemVersion) &&
-            BuildParameters.IsRunningOnAppVeyor)
+        var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.xml");
+        if (FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
         {
-            // Required to work correctly with appveyor because environment changes isn't detected until cake is done running.
-            var buildVersion = string.Format("{0}.build.{1}",
-                BuildParameters.Version.FullSemVersion,
-                BuildSystem.AppVeyor.Environment.Build.Number);
-            settings.EnvironmentVariables = new Dictionary<string, string> { { "APPVEYOR_BUILD_VERSION", buildVersion }};
+            coverageFiles += BuildParameters.Paths.Files.TestCoverageOutputFilePath;
         }
 
-        Codecov(settings);
+        if (coverageFiles.Any())
+        {
+            var settings = new CodecovSettings {
+                Files = coverageFiles.Select(f => f.FullPath),
+                Required = true
+            };
+            if (BuildParameters.Version != null &&
+                !string.IsNullOrEmpty(BuildParameters.Version.FullSemVersion) &&
+                BuildParameters.IsRunningOnAppVeyor)
+            {
+                // Required to work correctly with appveyor because environment changes isn't detected until cake is done running.
+                var buildVersion = string.Format("{0}.build.{1}",
+                    BuildParameters.Version.FullSemVersion,
+                    BuildSystem.AppVeyor.Environment.Build.Number);
+                settings.EnvironmentVariables = new Dictionary<string, string> { { "APPVEYOR_BUILD_VERSION", buildVersion }};
+            }
+
+            Codecov(settings);
+        }
     })
 ).OnError (exception =>
 {

--- a/Cake.Recipe/Content/coveralls.cake
+++ b/Cake.Recipe/Content/coveralls.cake
@@ -3,17 +3,25 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 BuildParameters.Tasks.UploadCoverallsReportTask = Task("Upload-Coveralls-Report")
-    .WithCriteria(() => FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
     .WithCriteria(() => !BuildParameters.IsLocalBuild)
     .WithCriteria(() => !BuildParameters.IsPullRequest)
     .WithCriteria(() => BuildParameters.IsMainRepository)
     .Does(() => RequireTool(ToolSettings.CoverallsTool, () => {
         if (BuildParameters.CanPublishToCoveralls)
         {
-            CoverallsIo(BuildParameters.Paths.Files.TestCoverageOutputFilePath, new CoverallsIoSettings()
+            var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.xml");
+            if (FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
             {
-                RepoToken = BuildParameters.Coveralls.RepoToken
-            });
+                coverageFiles += BuildParameters.Paths.Files.TestCoverageOutputFilePath;
+            }
+
+            foreach(var coverageFile in coverageFiles)
+            {
+                CoverallsIo(BuildParameters.Paths.Files.TestCoverageOutputFilePath, new CoverallsIoSettings()
+                {
+                    RepoToken = BuildParameters.Coveralls.RepoToken
+                });
+            }
         }
         else
         {

--- a/Cake.Recipe/Content/paths.cake
+++ b/Cake.Recipe/Content/paths.cake
@@ -220,6 +220,7 @@ public class BuildDirectories
             Build,
             TempBuild,
             TestResults,
+            TestCoverage.Combine("coverlet"),
             TestCoverage
         };
     }


### PR DESCRIPTION
I decided to not fallback to the coverlet utility when a unit testing project don't have it referenced. I decided because the addin `Cake.Coverlet` unfortunately have hard-coded the calls to that utility in debug build, and can not be changed.

fixes #356 