### PR TITLE
(GH-502) Set configuration during package restore

### DIFF
--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -172,7 +172,8 @@ BuildParameters.Tasks.DotNetCoreRestoreTask = Task("DotNetCore-Restore")
                             .WithProperty("Version", BuildParameters.Version.SemVersion)
                             .WithProperty("AssemblyVersion", BuildParameters.Version.Version)
                             .WithProperty("FileVersion",  BuildParameters.Version.Version)
-                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
+                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
+                            .WithProperty("Configuration", BuildParameters.Configuration);
 
     if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
     {


### PR DESCRIPTION
The changes in this PR forces the dotnet restore command to restore packages using the configured Debug/Release configuration.

If this is not passed in, this can cause issues when a project have conditional package restoring (like only some packages should be restored during debugging, like packages hooking into the visual studio debugger which is not needed when producing a production build).

fixes #502