### PR TITLE
(GH-525) Update to Cake.Issues.Recipe 0.3.3

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -17,7 +17,7 @@
 #addin nuget:?package=Cake.Twitter&version=0.10.1
 #addin nuget:?package=Cake.Wyam&version=2.2.7
 
-#load nuget:?package=Cake.Issues.Recipe&version=0.3.2
+#load nuget:?package=Cake.Issues.Recipe&version=0.3.3
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));


### PR DESCRIPTION
Update to Cake.Issues.Recipe [0.3.3](https://github.com/cake-contrib/Cake.Issues.Recipe/releases/tag/0.3.3). This will also update Cake.Git to [0.22.0](https://github.com/cake-contrib/Cake_Git/releases/tag/v0.22.0).

Fixes #525