### PR TITLE
(maint) Updated build providers to have a single task for printing environment variables

### DIFF
--- a/Cake.Recipe/Content/appveyor.cake
+++ b/Cake.Recipe/Content/appveyor.cake
@@ -2,38 +2,6 @@
 // TASK DEFINITIONS
 ///////////////////////////////////////////////////////////////////////////////
 
-BuildParameters.Tasks.PrintAppVeyorEnvironmentVariablesTask = Task("Print-AppVeyor-Environment-Variables")
-    .WithCriteria(() => AppVeyor.IsRunningOnAppVeyor, "Skipping because not running an AppVeyor")
-    .Does(() =>
-{
-    Information("CI: {0}", EnvironmentVariable("CI"));
-    Information("APPVEYOR_API_URL: {0}", EnvironmentVariable("APPVEYOR_API_URL"));
-    Information("APPVEYOR_PROJECT_ID: {0}", EnvironmentVariable("APPVEYOR_PROJECT_ID"));
-    Information("APPVEYOR_PROJECT_NAME: {0}", EnvironmentVariable("APPVEYOR_PROJECT_NAME"));
-    Information("APPVEYOR_PROJECT_SLUG: {0}", EnvironmentVariable("APPVEYOR_PROJECT_SLUG"));
-    Information("APPVEYOR_BUILD_FOLDER: {0}", EnvironmentVariable("APPVEYOR_BUILD_FOLDER"));
-    Information("APPVEYOR_BUILD_ID: {0}", EnvironmentVariable("APPVEYOR_BUILD_ID"));
-    Information("APPVEYOR_BUILD_NUMBER: {0}", EnvironmentVariable("APPVEYOR_BUILD_NUMBER"));
-    Information("APPVEYOR_BUILD_VERSION: {0}", EnvironmentVariable("APPVEYOR_BUILD_VERSION"));
-    Information("APPVEYOR_PULL_REQUEST_NUMBER: {0}", EnvironmentVariable("APPVEYOR_PULL_REQUEST_NUMBER"));
-    Information("APPVEYOR_PULL_REQUEST_TITLE: {0}", EnvironmentVariable("APPVEYOR_PULL_REQUEST_TITLE"));
-    Information("APPVEYOR_JOB_ID: {0}", EnvironmentVariable("APPVEYOR_JOB_ID"));
-    Information("APPVEYOR_REPO_PROVIDER: {0}", EnvironmentVariable("APPVEYOR_REPO_PROVIDER"));
-    Information("APPVEYOR_REPO_SCM: {0}", EnvironmentVariable("APPVEYOR_REPO_SCM"));
-    Information("APPVEYOR_REPO_NAME: {0}", EnvironmentVariable("APPVEYOR_REPO_NAME"));
-    Information("APPVEYOR_REPO_BRANCH: {0}", EnvironmentVariable("APPVEYOR_REPO_BRANCH"));
-    Information("APPVEYOR_REPO_TAG: {0}", EnvironmentVariable("APPVEYOR_REPO_TAG"));
-    Information("APPVEYOR_REPO_TAG_NAME: {0}", EnvironmentVariable("APPVEYOR_REPO_TAG_NAME"));
-    Information("APPVEYOR_REPO_COMMIT: {0}", EnvironmentVariable("APPVEYOR_REPO_COMMIT"));
-    Information("APPVEYOR_REPO_COMMIT_AUTHOR: {0}", EnvironmentVariable("APPVEYOR_REPO_COMMIT_AUTHOR"));
-    Information("APPVEYOR_REPO_COMMIT_TIMESTAMP: {0}", EnvironmentVariable("APPVEYOR_REPO_COMMIT_TIMESTAMP"));
-    Information("APPVEYOR_SCHEDULED_BUILD: {0}", EnvironmentVariable("APPVEYOR_SCHEDULED_BUILD"));
-    Information("APPVEYOR_FORCED_BUILD: {0}", EnvironmentVariable("APPVEYOR_FORCED_BUILD"));
-    Information("APPVEYOR_RE_BUILD: {0}", EnvironmentVariable("APPVEYOR_RE_BUILD"));
-    Information("PLATFORM: {0}", EnvironmentVariable("PLATFORM"));
-    Information("CONFIGURATION: {0}", EnvironmentVariable("CONFIGURATION"));
-});
-
 BuildParameters.Tasks.ClearAppVeyorCacheTask = Task("Clear-AppVeyor-Cache")
     .Does(() =>
         RequireAddin(@"#addin nuget:?package=Cake.AppVeyor&version=4.0.0&loaddependencies=true
@@ -115,6 +83,34 @@ public class AppVeyorBuildProvider : IBuildProvider
     public IPullRequestInfo PullRequest { get; }
 
     public IBuildInfo Build { get; }
+
+    public IEnumerable<string> PrintVariables { get; } = new[] {
+        "APPVEYOR_API_URL",
+        "APPVEYOR_BUILD_FOLDER",
+        "APPVEYOR_BUILD_ID",
+        "APPVEYOR_BUILD_NUMBER",
+        "APPVEYOR_BUILD_VERSION",
+        "APPVEYOR_FORCED_BUILD",
+        "APPVEYOR_JOB_ID",
+        "APPVEYOR_PROJECT_ID",
+        "APPVEYOR_PROJECT_NAME",
+        "APPVEYOR_PROJECT_SLUG",
+        "APPVEYOR_PULL_REQUEST_NUMBER",
+        "APPVEYOR_PULL_REQUEST_TITLE",
+        "APPVEYOR_RE_BUILD",
+        "APPVEYOR_REPO_COMMIT_AUTHOR",
+        "APPVEYOR_REPO_COMMIT_AUTHOR",
+        "APPVEYOR_REPO_COMMIT_TIMESTAMP",
+        "APPVEYOR_REPO_NAME",
+        "APPVEYOR_REPO_PROVIDER",
+        "APPVEYOR_REPO_SCM",
+        "APPVEYOR_REPO_TAG_NAME",
+        "APPVEYOR_REPO_TAG",
+        "APPVEYOR_SCHEDULED_BUILD",
+        "CI",
+        "CONFIGURATION",
+        "PLATFORM",
+    };
 
     private readonly IAppVeyorProvider _appVeyor;
 

--- a/Cake.Recipe/Content/azurepipelines.cake
+++ b/Cake.Recipe/Content/azurepipelines.cake
@@ -72,6 +72,19 @@ public class AzurePipelinesBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
+    public IEnumerable<string> PrintVariables { get; } = new[] {
+        "BUILD_BUILDID",
+        "BUILD_BUILDNUMBER",
+        "BUILD_REPOSITORY_NAME",
+        "BUILD_SOURCEBRANCHNAME",
+        "BUILD_SOURCEVERSION",
+        "SYSTEM_PULLREQUEST_PULLREQUESTNUMBER",
+        "SYSTEM_PULLREQUEST_TARGETBRANCH",
+        "SYSTEM_TEAMFOUNDATIONSERVERURI",
+        "SYSTEM_TEAMPROJECT",
+        "TF_BUILD",
+    };
+
     private readonly ITFBuildProvider _tfBuild;
 
     public void UploadArtifact(FilePath file)

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -144,8 +144,7 @@ BuildParameters.Tasks.ShowInfoTask = Task("Show-Info")
 
 BuildParameters.Tasks.CleanTask = Task("Clean")
     .IsDependentOn("Show-Info")
-    .IsDependentOn("Print-AppVeyor-Environment-Variables")
-    .IsDependentOn("Print-Travis-Ci-Environment-Variables")
+    .IsDependentOn("Print-CI-Provider-Environment-Variables")
     .Does(() =>
 {
     Information("Cleaning...");

--- a/Cake.Recipe/Content/buildProvider.cake
+++ b/Cake.Recipe/Content/buildProvider.cake
@@ -1,3 +1,22 @@
+BuildParameters.Tasks.PrintCiProviderEnvironmentVariablesTask = Task("Print-CI-Provider-Environment-Variables")
+    .Does(() =>
+{
+        var variables = BuildParameters.BuildProvider.PrintVariables ?? Enumerable.Empty<string>();
+        if (!variables.Any())
+        {
+            Information("No environment variables is available for current provider.");
+            return;
+        }
+
+        var maxlen = variables.Max(v => v.Length);
+
+        foreach (var variable in variables.OrderBy(v => v.Length).ThenBy(v => v))
+        {
+            var padKey = variable.PadLeft(maxlen);
+            Information("{0}: {1}", padKey, EnvironmentVariable(variable));
+        }
+});
+
 public interface ITagInfo
 {
     bool IsTag { get; }
@@ -31,6 +50,8 @@ public interface IBuildProvider
     IPullRequestInfo PullRequest { get; }
 
     IBuildInfo Build { get; }
+
+    IEnumerable<string> PrintVariables { get; }
 
     void UploadArtifact(FilePath file);
 }

--- a/Cake.Recipe/Content/localbuild.cake
+++ b/Cake.Recipe/Content/localbuild.cake
@@ -120,6 +120,8 @@ public class LocalBuildBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
+    public IEnumerable<string> PrintVariables { get; }
+
     private readonly ICakeContext _context;
 
     public void UploadArtifact(FilePath file)

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -3,8 +3,7 @@ public class BuildTasks
     public CakeTaskBuilder DupFinderTask { get; set; }
     public CakeTaskBuilder InspectCodeTask { get; set; }
     public CakeTaskBuilder AnalyzeTask { get; set; }
-    public CakeTaskBuilder PrintAppVeyorEnvironmentVariablesTask { get; set; }
-    public CakeTaskBuilder PrintTravisCiEnvironmentVariablesTask { get; set; }
+    public CakeTaskBuilder PrintCiProviderEnvironmentVariablesTask { get; set; }
     public CakeTaskBuilder UploadArtifactsTask { get; set; }
     public CakeTaskBuilder ClearAppVeyorCacheTask { get; set; }
     public CakeTaskBuilder ShowInfoTask { get; set; }

--- a/Cake.Recipe/Content/teamcity.cake
+++ b/Cake.Recipe/Content/teamcity.cake
@@ -90,6 +90,16 @@ public class TeamCityBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
+    public IEnumerable<string> PrintVariables { get; } = new[] {
+        "TEAMCITY_BUILD_BRANCH",
+        "TEAMCITY_BUILD_COMMIT",
+        "TEAMCITY_BUILD_ID",
+        "TEAMCITY_BUILD_REPOSITORY",
+        "TEAMCITY_BUILD_URL",
+        "TEAMCITY_VERSION",
+        "vcsroot.branch",
+    };
+
     private readonly ITeamCityProvider _teamCity;
 
     public void UploadArtifact(FilePath file)

--- a/Cake.Recipe/Content/travis-ci.cake
+++ b/Cake.Recipe/Content/travis-ci.cake
@@ -1,32 +1,3 @@
-BuildParameters.Tasks.PrintTravisCiEnvironmentVariablesTask = Task("Print-Travis-Ci-Environment-Variables")
-    .WithCriteria(() => TravisCI.IsRunningOnTravisCI, "Skipping because not running on Travis CI")
-    .Does(() =>
-{
-    Information("CI: {0}", EnvironmentVariable("CI"));
-    Information("TRAVIS: {0}", EnvironmentVariable("TRAVIS"));
-    Information("TRAVIS_BRANCH: {0}", EnvironmentVariable("TTRAVIS_BRANCH"));
-    Information("TRAVIS_BUILD_DIR: {0}", EnvironmentVariable("TRAVIS_BUILD_DIR"));
-    Information("TRAVIS_BUILD_ID: {0}", EnvironmentVariable("TRAVIS_BUILD_ID"));
-    Information("TRAVIS_BUILD_NUMBER: {0}", EnvironmentVariable("TRAVIS_BUILD_NUMBER"));
-    Information("TRAVIS_COMMIT: {0}", EnvironmentVariable("TRAVIS_COMMIT"));
-    Information("TRAVIS_COMMIT_MESSAGE: {0}", EnvironmentVariable("TRAVIS_COMMIT_MESSAGE"));
-    Information("TRAVIS_COMMIT_RANGE: {0}", EnvironmentVariable("TRAVIS_COMMIT_RANGE"));
-    Information("TRAVIS_CPU_ARCH: {0}", EnvironmentVariable("TRAVIS_CPU_ARCH"));
-    Information("TRAVIS_DIST: {0}", EnvironmentVariable("TRAVIS_DIST"));
-    Information("TRAVIS_JOB_ID: {0}", EnvironmentVariable("TRAVIS_JOB_ID"));
-    Information("TRAVIS_JOB_NAME: {0}", EnvironmentVariable("TRAVIS_JOB_NAME"));
-    Information("TRAVIS_JOB_NUMBER: {0}", EnvironmentVariable("TRAVIS_JOB_NUMBER"));
-    Information("TRAVIS_JOB_WEB_URL: {0}", EnvironmentVariable("TRAVIS_JOB_WEB_URL"));
-    Information("TRAVIS_OS_NAME: {0}", EnvironmentVariable("TRAVIS_OS_NAME"));
-    Information("TRAVIS_OSX_IMAGE: {0}", EnvironmentVariable("TRAVIS_OSX_IMAGE"));
-    Information("TRAVIS_PROJECT_SLUG: {0}", EnvironmentVariable("TRAVIS_PROJECT_SLUG"));
-    Information("TRAVIS_PULL_REQUEST: {0}", EnvironmentVariable("TRAVIS_PULL_REQUEST"));
-    Information("TRAVIS_PULL_REQUEST_BRANCH: {0}", EnvironmentVariable("TRAVIS_PULL_REQUEST_BRANCH"));
-    Information("TRAVIS_PULL_REQUEST_SHA: {0}", EnvironmentVariable("TRAVIS_PULL_REQUEST_SHA"));
-    Information("TRAVIS_PULL_REQUEST_SLUG: {0}", EnvironmentVariable("TRAVIS_PULL_REQUEST_SLUG"));
-    Information("TRAVIS_TAG: {0}", EnvironmentVariable("TRAVIS_TAG"));
-});
-
 public class TravisCiTagInfo : ITagInfo
 {
     public TravisCiTagInfo(ITravisCIProvider travisCi)
@@ -88,6 +59,32 @@ public class TravisCiBuildProvider : IBuildProvider
     public IBuildInfo Build { get; }
     public IPullRequestInfo PullRequest { get; }
     public IRepositoryInfo Repository { get; }
+
+    public IEnumerable<string> PrintVariables { get; } = new[] {
+        "CI",
+        "TRAVIS",
+        "TRAVIS_BRANCH",
+        "TRAVIS_BUILD_DIR",
+        "TRAVIS_BUILD_ID",
+        "TRAVIS_BUILD_NUMBER",
+        "TRAVIS_COMMIT",
+        "TRAVIS_COMMIT_MESSAGE",
+        "TRAVIS_COMMIT_RANGE",
+        "TRAVIS_CPU_ARCH",
+        "TRAVIS_DIST",
+        "TRAVIS_JOB_ID",
+        "TRAVIS_JOB_NAME",
+        "TRAVIS_JOB_NUMBER",
+        "TRAVIS_JOB_WEB_URL",
+        "TRAVIS_OS_NAME",
+        "TRAVIS_OSX_IMAGE",
+        "TRAVIS_PROJECT_SLUG",
+        "TRAVIS_PULL_REQUEST",
+        "TRAVIS_PULL_REQUEST_BRANCH",
+        "TRAVIS_PULL_REQUEST_SHA",
+        "TRAVIS_PULL_REQUEST_SLUG",
+        "TRAVIS_TAG"
+    };
 
     public void UploadArtifact(FilePath file)
     {


### PR DESCRIPTION
This pull request updates the existing build providers to use a single Task to report the different environment variables available in each CI system.
This makes it easier to add additional environment variables in the future for different providers if/when there is a need to do so.

An example of the output can be seen here: https://ci.appveyor.com/project/AdmiringWorm/cake-recipe/builds/33964080#L220 (since it won't show on the pr build without dogfooding Cake.Recipe).

/cc @gep13 