### PR TITLE
(GH-533) Change to only compare major minor version of cake + dogfooding

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 #  Build Script                   #
 #---------------------------------#
 build_script:
-  - ps: .\build.ps1 -Target AppVeyor
+  - ps: .\build.ps1 -Target ContinuousIntegration
 
 # Tests
 test: off

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,6 @@ indent_size = 4
 [*.js]
 indent_style = tab
 indent_size = 2
+
+[*.sh]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,9 @@
 # Custom for Visual Studio
 *.cs     diff=csharp
 
+# Shellscripts on Unix is required to use LF line endings
+*.sh eol=LF
+
 # Standard to msysgit
 *.doc	 diff=astextplain
 *.DOC	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -257,6 +257,7 @@ BuildArtifacts/
 *.temp.nuspec
 tests/integration/repos/
 Cake.Recipe/Content/version.cake
+includes.cake
 
 # Wyam related
 docs/config.wyam.dll

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -6,6 +6,17 @@ var publishingError = false;
 var currentSupportedCakeVersionNumber = "0.33.0.0";
 
 ///////////////////////////////////////////////////////////////////////////////
+// Support function for comparing cake version support
+///////////////////////////////////////////////////////////////////////////////
+public bool IsSupportedCakeVersion(string supportedVersion, string currentVersion)
+{
+    var twoPartSupported = Version.Parse(supportedVersion).ToString(2);
+    var twoPartCurrent = Version.Parse(currentVersion).ToString(2);
+
+    return twoPartCurrent == twoPartSupported;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // SETUP / TEARDOWN
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -36,7 +47,7 @@ Setup<BuildData>(context =>
         BuildMetaData.Version,
         BuildParameters.IsTagged);
 
-    if (BuildParameters.Version.CakeVersion != currentSupportedCakeVersionNumber)
+    if (!IsSupportedCakeVersion(currentSupportedCakeVersionNumber, BuildParameters.Version.CakeVersion))
     {
         throw new Exception(string.Format("Cake.Recipe currently only supports building projects using version {0} of Cake.  Please update your packages.config file (or whatever method is used to pin to a specific version of Cake) to use this version.", currentSupportedCakeVersionNumber));
     }

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -3,7 +3,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 var publishingError = false;
-var currentSupportedCakeVersionNumber = "0.33.0.0";
 
 ///////////////////////////////////////////////////////////////////////////////
 // Support function for comparing cake version support
@@ -47,9 +46,9 @@ Setup<BuildData>(context =>
         BuildMetaData.Version,
         BuildParameters.IsTagged);
 
-    if (!IsSupportedCakeVersion(currentSupportedCakeVersionNumber, BuildParameters.Version.CakeVersion))
+    if (!IsSupportedCakeVersion(BuildMetaData.CakeVersion, BuildParameters.Version.CakeVersion))
     {
-        throw new Exception(string.Format("Cake.Recipe currently only supports building projects using version {0} of Cake.  Please update your packages.config file (or whatever method is used to pin to a specific version of Cake) to use this version.", currentSupportedCakeVersionNumber));
+        throw new Exception(string.Format("Cake.Recipe currently only supports building projects using version {0} of Cake.  Please update your packages.config file (or whatever method is used to pin to a specific version of Cake) to use this version.", BuildMetaData.CakeVersion));
     }
 
     // Make sure build and linters run before issues task.

--- a/build.ps1
+++ b/build.ps1
@@ -65,7 +65,7 @@ try {
     }
   } catch {
     Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to upgrade to .NET Framework 4.5+ and PowerShell v3'
-  }
+}
 
 [Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
 function MD5HashFile([string] $filePath)
@@ -173,7 +173,7 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     # Check for changes in packages.config and remove installed tools if true.
     [string] $md5Hash = MD5HashFile $PACKAGES_CONFIG
     if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
-    ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
         Write-Verbose -Message "Missing or changed package.config hash..."
         Get-ChildItem -Exclude packages.config,nuget.exe,Cake.Bakery |
         Remove-Item -Recurse
@@ -249,6 +249,10 @@ if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
 if ($ShowDescription) { $cakeArguments += "-showdescription" }
 if ($DryRun) { $cakeArguments += "-dryrun" }
 $cakeArguments += $ScriptArgs
+
+Get-ChildItem "./Cake.Recipe/Content/*.cake" -Exclude "version.cake" | % {
+    "#load `"local:?path=$($_.FullName -replace '\\','/')`""
+} | Out-File "./includes.cake"
 
 # Start Cake
 Write-Host "Running build script..."

--- a/build.sh
+++ b/build.sh
@@ -113,5 +113,15 @@ if [ ! -f "$CAKE_EXE" ]; then
     exit 1
 fi
 
+if [ -f "./includes.cake" ]; then
+    rm -f "./includes.cake"
+fi
+
+for f in ./Cake.Recipe/Content/*.cake; do
+    if [ "$f" != "*/version.cake" ]; then
+        echo "#load \"local:?package=$f\"" >> ./includes.cake
+    fi
+done
+
 # Start Cake
 exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}"

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,11 @@
-#load nuget:?package=Cake.Recipe&version=1.0.0
+#load "./includes.cake"
+
+public class BuildMetaData
+{
+    public static string Date { get; } = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
+    public static string Version { get; } = "DogFood";
+    public static string CakeVersion { get; } = typeof(ICakeContext).Assembly.GetName().Version.ToString();
+}
 
 Environment.SetVariableNames();
 
@@ -25,12 +32,14 @@ Task("Generate-Version-File")
         {
             public static string Date { get; } = ""<%date%>"";
             public static string Version { get; } = ""<%version%>"";
+            public static string CakeVersion { get; } = ""<%cakeversion%>"";
         }",
         "<%",
         "%>"
         )
-   .WithToken("date", DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss"))
+   .WithToken("date", BuildMetaData.Date)
    .WithToken("version", BuildParameters.Version.SemVersion)
+   .WithToken("cakeversion", BuildMetaData.CakeVersion)
    .ToString();
 
     System.IO.File.WriteAllText(


### PR DESCRIPTION
- (GH-441) Update addins references
- (GH-441) Update Cake version in package.config
- (GH-533) Change to compare supported cake major-minor versions
- (maint) Dogfood current cake.recipe during building

This pull request adds a small helper that takes care of comparing the supported Cake version towards the one that the user is currently running.
This comparison helper only compares major+minor parts of the version, so users can still update patch releases without Cake.Recipe complaining.

This pull request changes the current build process to build Cake using the latest unstable source by making use of dogfooding,
this required an update of Cake version 0.33.0 and as such I merged in #442.
This can be rebased if that is desirable instead.

resolves #533