### PR TITLE
(GH-536) Add ability to ignore cake version when executing build

### DIFF
--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -48,7 +48,15 @@ Setup<BuildData>(context =>
 
     if (!IsSupportedCakeVersion(BuildMetaData.CakeVersion, BuildParameters.Version.CakeVersion))
     {
-        throw new Exception(string.Format("Cake.Recipe currently only supports building projects using version {0} of Cake.  Please update your packages.config file (or whatever method is used to pin to a specific version of Cake) to use this version.", BuildMetaData.CakeVersion));
+        if (HasArgument("ignore-cake-version"))
+        {
+            Warning("Currently running Cake version {0}. This version is not supported together with Cake.Recipe.", BuildParameters.Version.CakeVersion);
+            Warning("--ignore-cake-version Switch was found. Continuing execution of Cake.Recipe.");
+        }
+        else
+        {
+            throw new Exception(string.Format("Cake.Recipe currently only supports building projects using version {0} of Cake.  Please update your packages.config file (or whatever method is used to pin to a specific version of Cake) to use this version. Or use the --ignore-cake-version switch if you know what you are doing!", BuildMetaData.CakeVersion));
+        }
     }
 
     // Make sure build and linters run before issues task.


### PR DESCRIPTION
This pull request adds a simple way to disable the throwing of an error when the version of Cake do not match the version that Cake.Recipe was built with.
This switch `--ignore-cake-version` is used without any arguments to allow this to happen, a warning will be outputted to the user that he/she is running an unsupported/untested version of Cake, but execution of the build will be allowed to continue.

resolves #536
