### PR TITLE
(GH-531) Implemented build provider support for github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Only windows is possible until supported cake version
+        # is bumped to 0.37.0.0+.
+        # See https://github.com/cake-build/cake/issues/2695
+        os: [windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2.2.0
+        with:
+          fetch-depth: 0
+      - name: Build using bootstrapper
+        run: ./build.ps1 --verbosity=Diagnostic
+        shell: pwsh

--- a/Cake.Recipe/Content/buildProvider.cake
+++ b/Cake.Recipe/Content/buildProvider.cake
@@ -82,6 +82,12 @@ public static IBuildProvider GetBuildProvider(ICakeContext context, BuildSystem 
         return new TravisCiBuildProvider(buildSystem.TravisCI, context);
     }
 
+    if (context.EnvironmentVariable("GITHUB_ACTIONS", false) || !string.IsNullOrEmpty(context.EnvironmentVariable("GITHUB_ACTION")))
+    {
+        context.Information("Using GitHub Action Provider...");
+        return new GitHubActionBuildProvider(context);
+    }
+
     // always fallback to Local Build
     context.Information("Using Local Build Provider...");
     return new LocalBuildBuildProvider(context);

--- a/Cake.Recipe/Content/github-actions.cake
+++ b/Cake.Recipe/Content/github-actions.cake
@@ -23,14 +23,22 @@ public class GitHubActionRepositoryInfo : IRepositoryInfo
     public GitHubActionRepositoryInfo(ICakeContext context)
     {
         Name = context.EnvironmentVariable("GITHUB_REPOSITORY");
-        // This trimming is not perfect, as it will remove part of a
-        // branch name if the branch name itself contains a '/'
-        var tempName = context.EnvironmentVariable("GITHUB_REF");
-        if (!string.IsNullOrEmpty(tempName) && tempName.IndexOf('/') >= 0)
+        var baseRef = context.EnvironmentVariable("GITHUB_BASE_REF");
+        if (!string.IsNullOrEmpty(baseRef))
         {
-            tempName = tempName.Substring(tempName.LastIndexOf('/') + 1);
+            Branch = baseRef;
         }
-        Branch = tempName;
+        else
+        {
+            // This trimming is not perfect, as it will remove part of a
+            // branch name if the branch name itself contains a '/'
+            var tempName = context.EnvironmentVariable("GITHUB_REF");
+            if (!string.IsNullOrEmpty(tempName) && tempName.IndexOf('/') >= 0)
+            {
+                tempName = tempName.Substring(tempName.LastIndexOf('/') + 1);
+            }
+            Branch = tempName;
+        }
         Tag = new GitHubActionTagInfo(context);
     }
 

--- a/Cake.Recipe/Content/github-actions.cake
+++ b/Cake.Recipe/Content/github-actions.cake
@@ -1,0 +1,106 @@
+// TODO: Change direct environment grabbing to use
+// IGitHubActionsProvider when Cake.Recipe starts
+// using Cake version 0.36.0 or higher.
+
+public class GitHubActionTagInfo : ITagInfo
+{
+    public GitHubActionTagInfo(ICakeContext context)
+    {
+        var tempName = context.EnvironmentVariable("GITHUB_REF");
+        if (!string.IsNullOrEmpty(tempName) && tempName.IndexOf("tags/") >= 0)
+        {
+            IsTag = true;
+            Name = tempName.Substring(tempName.LastIndexOf('/') + 1);
+        }
+    }
+
+    public bool IsTag { get; }
+    public string Name { get; }
+}
+
+public class GitHubActionRepositoryInfo : IRepositoryInfo
+{
+    public GitHubActionRepositoryInfo(ICakeContext context)
+    {
+        Name = context.EnvironmentVariable("GITHUB_REPOSITORY");
+        // This trimming is not perfect, as it will remove part of a
+        // branch name if the branch name itself contains a '/'
+        var tempName = context.EnvironmentVariable("GITHUB_REF");
+        if (!string.IsNullOrEmpty(tempName) && tempName.IndexOf('/') >= 0)
+        {
+            tempName = tempName.Substring(tempName.LastIndexOf('/') + 1);
+        }
+        Branch = tempName;
+        Tag = new GitHubActionTagInfo(context);
+    }
+
+    public string Branch { get; }
+    public string Name { get; }
+    public ITagInfo Tag { get; }
+}
+
+public class GitHubActionPullRequestInfo : IPullRequestInfo
+{
+    public GitHubActionPullRequestInfo(ICakeContext context)
+    {
+        var headRef = context.EnvironmentVariable("GITHUB_HEAD_REF");
+        var branchRef = context.EnvironmentVariable("GITHUB_REF");
+
+        IsPullRequest = !string.IsNullOrEmpty(headRef) && !string.IsNullOrEmpty(branchRef)
+            && branchRef.IndexOf("refs/pull/") >= 0 && branchRef.IndexOf("/merge") >= 0;
+    }
+
+    public bool IsPullRequest { get; }
+}
+
+public class GitHubActionBuildInfo : IBuildInfo
+{
+    public GitHubActionBuildInfo(ICakeContext context)
+    {
+        Number = context.EnvironmentVariable("GITHUB_RUN_NUMBER");
+    }
+
+    public string Number { get; }
+}
+
+public class GitHubActionBuildProvider : IBuildProvider
+{
+    private readonly ICakeContext _context;
+
+    public GitHubActionBuildProvider(ICakeContext context)
+    {
+        Build = new GitHubActionBuildInfo(context);
+        PullRequest = new GitHubActionPullRequestInfo(context);
+        Repository = new GitHubActionRepositoryInfo(context);
+
+        _context = context;
+    }
+
+    public IBuildInfo Build { get; }
+    public IPullRequestInfo PullRequest { get; }
+    public IRepositoryInfo Repository { get; }
+
+    public IEnumerable<string> PrintVariables { get; } = new[] {
+        "CI",
+        "HOME",
+        "GITHUB_WORKFLOW",
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_NUMBER",
+        "GITHUB_ACTION",
+        "GITHUB_ACTIONS",
+        "GITHUB_ACTOR",
+        "GITHUB_REPOSITORY",
+        "GITHUB_EVENT_NAME",
+        "GITHUB_EVENT_PATH",
+        "GITHUB_WORKSPACE",
+        "GITHUB_SHA",
+        "GITHUB_REF",
+        "GITHUB_HEAD_REF",
+        "GITHUB_BASE_REF"
+    };
+
+    public void UploadArtifact(FilePath file)
+    {
+        _context.Information("Uploading artifacts is currently not supported in Cake.Recipe. Please use the actions/upload-artifacts GitHub Action");
+    }
+}

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -495,7 +495,8 @@ public static class BuildParameters
         CakeConfiguration = context.GetConfiguration();
         MasterBranchName = masterBranchName;
         DevelopBranchName = developBranchName;
-        IsLocalBuild = buildSystem.IsLocalBuild;
+        // Workaround until bumping to cake 0.37.0+
+        IsLocalBuild = buildSystem.IsLocalBuild && BuildProvider.GetType() != typeof(GitHubActionBuildProvider);
         IsRunningOnAppVeyor = buildSystem.AppVeyor.IsRunningOnAppVeyor;
         IsRunningOnTravisCI = buildSystem.IsRunningOnTravisCI;
         IsPullRequest = BuildProvider.PullRequest.IsPullRequest;

--- a/build.sh
+++ b/build.sh
@@ -119,7 +119,7 @@ fi
 
 for f in ./Cake.Recipe/Content/*.cake; do
     if [ "$f" != "*/version.cake" ]; then
-        echo "#load \"local:?package=$f\"" >> ./includes.cake
+        echo "#load \"local:?path=$f\"" >> ./includes.cake
     fi
 done
 


### PR DESCRIPTION
This pull request adds a new build provider that will be used when running Cake.Recipe on github actions.
This build provider should be updated once Cake.Recipe supports 0.36.0+ to use Cakes included BuildSystem support.

A small basic workflow file was also added to be able to verify build isn't breaking anything on gh actions.
Unfortunately only windows could be enable until Cake.Recipe supports Cake 0.37.0+

resolves #531

/cc @gep13