### PR TITLE
(GH-535) Provide ability to not use Coveralls

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -112,6 +112,7 @@ public static class BuildParameters
 
     public static bool ShouldRunDupFinder { get; private set; }
     public static bool ShouldRunInspectCode { get; private set; }
+    public static bool ShouldRunCoveralls { get; private set; }
     public static bool ShouldRunCodecov { get; private set; }
     public static bool ShouldRunDotNetCorePack { get; private set; }
     public static bool ShouldRunChocolatey { get; private set; }
@@ -225,7 +226,7 @@ public static class BuildParameters
     {
         get
         {
-            return !string.IsNullOrEmpty(BuildParameters.Coveralls.RepoToken);
+            return ShouldRunCoveralls && !string.IsNullOrEmpty(BuildParameters.Coveralls.RepoToken);
         }
     }
 
@@ -361,6 +362,7 @@ public static class BuildParameters
         bool shouldDocumentSourceFiles = true,
         bool shouldRunDupFinder = true,
         bool shouldRunInspectCode = true,
+        bool shouldRunCoveralls = true,
         bool shouldRunCodecov = false,
         bool shouldRunDotNetCorePack = false,
         bool shouldBuildNugetSourcePackage = false,
@@ -450,6 +452,7 @@ public static class BuildParameters
         ShouldDeleteCachedFiles = shouldDeleteCachedFiles;
         ShouldRunDupFinder = shouldRunDupFinder;
         ShouldRunInspectCode = shouldRunInspectCode;
+        ShouldRunCoveralls = shouldRunCoveralls;
         ShouldRunCodecov = shouldRunCodecov;
         ShouldRunDotNetCorePack = shouldRunDotNetCorePack;
         ShouldBuildNugetSourcePackage = shouldBuildNugetSourcePackage;


### PR DESCRIPTION
Previously, it was assumed that you would always publish to Coveralls,
and the only way to prevent it was to hack the environment variable to
be something that couldn't be found.  This new parameter allows
controlling whether Coveralls should be used.  It will default to true,
since that is how things work just now.

Fixes #535 