### PR TITLE
(GH-299) Change how notifications are sent

### DIFF
--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -71,7 +71,7 @@ Teardown(context =>
 {
     Information("Starting Teardown...");
 
-    if (context.Successful)
+    if (BuildParameters.PublishReleasePackagesWasSuccessful)
     {
         if (!BuildParameters.IsLocalBuild && !BuildParameters.IsPullRequest && BuildParameters.IsMainRepository && (BuildParameters.BranchType == BranchType.Master || ((BuildParameters.BranchType == BranchType.Release || BuildParameters.BranchType == BranchType.HotFix) && BuildParameters.ShouldNotifyBetaReleases)) && BuildParameters.IsTagged)
         {
@@ -107,7 +107,8 @@ Teardown(context =>
             }
         }
     }
-    else
+
+    if(!context.Successful)
     {
         if (!BuildParameters.IsLocalBuild && BuildParameters.IsMainRepository)
         {

--- a/Cake.Recipe/Content/packages.cake
+++ b/Cake.Recipe/Content/packages.cake
@@ -167,6 +167,8 @@ BuildParameters.Tasks.PublishReleasePackagesTask = Task("Publish-Release-Package
     PushChocolateyPackages(Context, true, chocolateySources);
 
     PushNuGetPackages(Context, true, nugetSources);
+
+    BuildParameters.PublishReleasePackagesWasSuccessful = true;
 })
 .OnError(exception =>
 {

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -32,6 +32,7 @@ public static class BuildParameters
     public static bool TransifexEnabled { get; set; }
     public static bool PrepareLocalRelease { get; set; }
     public static bool TreatWarningsAsErrors { get; set; }
+    public static bool PublishReleasePackagesWasSuccessful { get; set; }
     public static bool ShouldPublishToMyGetWithApiKey { get; set; }
     public static string MasterBranchName { get; private set; }
     public static string DevelopBranchName { get; private set; }


### PR DESCRIPTION
Previously, a build had to be completely successful before notifications
were sent to Twitter/Gitter, etc.  However, it is possible to some
publishing tasks fail, but the artifacts are still sent to their end
location, i.e NuGet.org.  In these cases, it would make sense for the
notifications to be sent, since the packages have been released.  As
such, the Teardown method has been updated to send notifications, when
it knows artifacts have been sent successfully.

Fixes #299 