### PR TITLE
(GH-217) Add ability to override versioning

### DIFF
--- a/Cake.Recipe/Content/gitreleasemanager.cake
+++ b/Cake.Recipe/Content/gitreleasemanager.cake
@@ -3,13 +3,13 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 BuildParameters.Tasks.CreateReleaseNotesTask = Task("Create-Release-Notes")
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {
             var settings = new GitReleaseManagerCreateSettings
             {
-                Milestone         = BuildParameters.Version.Milestone,
-                Name              = BuildParameters.Version.Milestone,
+                Milestone         = buildVersion.Milestone,
+                Name              = buildVersion.Milestone,
                 TargetCommitish   = BuildParameters.MasterBranchName,
                 Prerelease        = false
             };
@@ -37,14 +37,14 @@ BuildParameters.Tasks.ExportReleaseNotesTask = Task("Export-Release-Notes")
     .WithCriteria(() => BuildParameters.IsMainRepository || BuildParameters.PrepareLocalRelease, "Is not main repository, and is not preparing local release")
     .WithCriteria(() => BuildParameters.BranchType == BranchType.Master || BuildParameters.BranchType == BranchType.Release || BuildParameters.BranchType == BranchType.HotFix || BuildParameters.PrepareLocalRelease, "Is not a releasable branch, and is not preparing local release")
     .WithCriteria(() => BuildParameters.IsTagged || BuildParameters.PrepareLocalRelease, "Is not a tagged build, and is not preparing local release")
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {
             if (BuildParameters.ShouldDownloadMilestoneReleaseNotes)
             {
                 var settings = new GitReleaseManagerExportSettings
                 {
-                    TagName         = BuildParameters.Version.Milestone
+                    TagName         = buildVersion.Milestone
                 };
 
                 if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
@@ -79,7 +79,7 @@ BuildParameters.Tasks.ExportReleaseNotesTask = Task("Export-Release-Notes")
 BuildParameters.Tasks.PublishGitHubReleaseTask = Task("Publish-GitHub-Release")
     .IsDependentOn("Package")
     .WithCriteria(() => BuildParameters.ShouldPublishGitHub)
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {
             // Concatenating FilePathCollections should make sure we get unique FilePaths
@@ -89,21 +89,21 @@ BuildParameters.Tasks.PublishGitHubReleaseTask = Task("Publish-GitHub-Release")
             {
                 if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
                 {
-                    GitReleaseManagerAddAssets(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.Milestone, package.ToString());
+                    GitReleaseManagerAddAssets(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone, package.ToString());
                 }
                 else
                 {
-                    GitReleaseManagerAddAssets(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.Milestone, package.ToString());
+                    GitReleaseManagerAddAssets(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone, package.ToString());
                 }
             }
 
             if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
             {
-                GitReleaseManagerClose(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.Milestone);
+                GitReleaseManagerClose(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone);
             }
             else
             {
-                GitReleaseManagerClose(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.Milestone);
+                GitReleaseManagerClose(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone);
             }
         }
         else

--- a/Cake.Recipe/Content/gitter.cake
+++ b/Cake.Recipe/Content/gitter.cake
@@ -2,14 +2,14 @@
 // HELPER METHODS
 ///////////////////////////////////////////////////////////////////////////////
 
-public void SendMessageToGitterRoom()
+public void SendMessageToGitterRoom(string message)
 {
     try
     {
         Information("Sending message to Gitter...");
 
         var postMessageResult = Gitter.Chat.PostMessage(
-                    message: BuildParameters.GitterMessage,
+                    message: message,
                     messageSettings: new GitterChatMessageSettings { Token = BuildParameters.Gitter.Token, RoomId = BuildParameters.Gitter.RoomId}
             );
 

--- a/Cake.Recipe/Content/microsoftteams.cake
+++ b/Cake.Recipe/Content/microsoftteams.cake
@@ -2,13 +2,13 @@
 // HELPER METHODS
 ///////////////////////////////////////////////////////////////////////////////
 
-public void SendMessageToMicrosoftTeams()
+public void SendMessageToMicrosoftTeams(string message)
 {
     try
     {
         Information("Sending message to Microsoft Teams...");
 
-        MicrosoftTeamsPostMessage(BuildParameters.MicrosoftTeamsMessage,
+        MicrosoftTeamsPostMessage(message,
             new MicrosoftTeamsSettings {
                 IncomingWebhookUrl = BuildParameters.MicrosoftTeams.WebHookUrl
         });

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -45,7 +45,7 @@ public static class BuildParameters
 
     public static string StandardMessage
     {
-        get { return $"Version {Version.SemVersion} of the {Title} Addin has just been released, this will be available here https://www.nuget.org/packages/{Title}, once package indexing is complete."; }
+        get { return "Version {0} of the {1} Addin has just been released, this will be available here https://www.nuget.org/packages/{1}, once package indexing is complete."; }
     }
 
     public static string GitterMessage
@@ -77,7 +77,6 @@ public static class BuildParameters
     public static CoverallsCredentials Coveralls { get; private set; }
     public static TransifexCredentials Transifex { get; private set; }
     public static WyamCredentials Wyam { get; private set; }
-    public static BuildVersion Version { get; private set; }
     public static BuildPaths Paths { get; private set; }
     public static BuildTasks Tasks { get; set; }
     public static DirectoryPath RootDirectoryPath { get; private set; }
@@ -249,11 +248,6 @@ public static class BuildParameters
                 && (BuildParameters.IsRunningOnAppVeyor
                     || string.Equals(BuildParameters.Target, "Transifex-Push-SourceFiles", StringComparison.OrdinalIgnoreCase));
         }
-    }
-
-    public static void SetBuildVersion(BuildVersion version)
-    {
-        Version  = version;
     }
 
     public static void SetBuildPaths(BuildPaths paths)

--- a/Cake.Recipe/Content/twitter.cake
+++ b/Cake.Recipe/Content/twitter.cake
@@ -2,7 +2,7 @@
 // HELPER METHODS
 ///////////////////////////////////////////////////////////////////////////////
 
-public void SendMessageToTwitter()
+public void SendMessageToTwitter(string message)
 {
     try
     {
@@ -12,7 +12,7 @@ public void SendMessageToTwitter()
                          BuildParameters.Twitter.ConsumerSecret,
                          BuildParameters.Twitter.AccessToken,
                          BuildParameters.Twitter.AccessTokenSecret,
-                         BuildParameters.TwitterMessage);
+                         message);
 
         Information("Message successfully sent.");
     }

--- a/recipe.cake
+++ b/recipe.cake
@@ -26,7 +26,7 @@ BuildParameters.Tasks.CleanTask
     .IsDependentOn("Generate-Version-File");
 
 Task("Generate-Version-File")
-    .Does(() => {
+    .Does<BuildVersion>((context, buildVersion) => {
         var buildMetaDataCodeGen = TransformText(@"
         public class BuildMetaData
         {
@@ -38,7 +38,7 @@ Task("Generate-Version-File")
         "%>"
         )
    .WithToken("date", BuildMetaData.Date)
-   .WithToken("version", BuildParameters.Version.SemVersion)
+   .WithToken("version", buildVersion.SemVersion)
    .WithToken("cakeversion", BuildMetaData.CakeVersion)
    .ToString();
 
@@ -50,11 +50,11 @@ Task("Generate-Version-File")
 
 Task("Run-Local-Integration-Tests")
     .IsDependentOn("Default")
-    .Does(() => {
+    .Does<BuildVersion>((context, buildVersion) => {
     CakeExecuteScript("./test.cake",
         new CakeSettings {
             Arguments = new Dictionary<string, string>{
-                { "recipe-version", BuildParameters.Version.SemVersion },
+                { "recipe-version", buildVersion.SemVersion },
                 { "verbosity", Context.Log.Verbosity.ToString("F") }
             }});
 });


### PR DESCRIPTION
When you want to use something other than GitVersion to perform the
versioning of the repository, you can override the new Setup method,
and as long as you provide a BuildVersion instance, the remainder of
the code should work as expected.

Fixes #217 