### PR TITLE
(GH-80) Set milestone to correct version number

### DIFF
--- a/Cake.Recipe/Content/gitversion.cake
+++ b/Cake.Recipe/Content/gitversion.cake
@@ -73,7 +73,7 @@ public class BuildVersion
             semVersion = assertedVersions.LegacySemVerPadded;
             informationalVersion = assertedVersions.InformationalVersion;
             assemblySemVer = assertedVersions.AssemblySemVer;
-            milestone = string.Concat(version);
+            milestone = assertedVersions.SemVer;
             fullSemVersion = assertedVersions.FullSemVer;
 
             context.Information("Calculated Semantic Version: {0}", semVersion);


### PR DESCRIPTION
There is a slight edge case where artifacts are pushed to the wrong
GitHub release.  Rather then set milestone to MajorMinorPatch, use the
asserted SemVer version instead.

Fixes #80 