### PR TITLE
(GH-379) Use msbuild on unix when it is available

### DIFF
--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -224,7 +224,7 @@ BuildParameters.Tasks.BuildTask = Task("Build")
     .Does<BuildVersion>((context, buildVersion) => RequireTool(ToolSettings.MSBuildExtensionPackTool, () => {
         Information("Building {0}", BuildParameters.SolutionFilePath);
 
-        if (BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows)
+        if (BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows || Context.Tools.Resolve("msbuild") != null)
         {
             var msbuildSettings = new MSBuildSettings()
                 .SetPlatformTarget(ToolSettings.BuildPlatformTarget)


### PR DESCRIPTION
This pull request adds the ability to use msbuild on unix platforms when the executable is available.

With a fallback to xbuild if msbuild could not be found

resolves #379
