### PR TITLE
(maint) Manual resolving of gitversion on unix platforms

### DIFF
--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -25,6 +25,12 @@ Setup<BuildVersion>(context =>
     BuildVersion buildVersion = null;
 
     RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitVersionGlobalTool : ToolSettings.GitVersionTool, () => {
+        if (!BuildParameters.IsDotNetCoreBuild && BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
+        {
+            var gitversionPath = context.Tools.Resolve("gitversion.exe");
+            context.Tools.RegisterFile(gitversionPath);
+        }
+
         buildVersion = BuildVersion.CalculatingSemanticVersion(
                 context: Context
             );


### PR DESCRIPTION
When running Cake.Recipe using mono on unix platfroms, the resolving of GitVersion is not possible due to case sensitiv mismatch.

This pull request adds a manual resolving and registration of the gitversion.exe executable when running as a msbuild project and platform is not windows.