### PR TITLE
(GH-552) Use earlier version of GitVersion

### DIFF
--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -43,7 +43,7 @@ public static class ToolSettings
         string codecovTool = "#tool nuget:?package=codecov&version=1.12.0",
         string coverallsTool = "#tool nuget:?package=coveralls.net&version=1.0.0",
         string gitReleaseManagerTool = "#tool nuget:?package=GitReleaseManager&version=0.11.0",
-        string gitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=5.3.4",
+        string gitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=5.0.1",
         string reSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2019.3.4",
         string reSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.4.0",
         string kuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.5.3",


### PR DESCRIPTION
After this version, 5.0.1, GitVersion started shipping as a single
contained executable, which means it no longer supports running with
Mono, and as a result, Cake.Recipe won't work on Unix systems.  To
enable support on these platforms, need to pin to this specific version.

Fixes #552 