### PR TITLE
(maint) Correct coverage file paths passed to ReportGenerator

### DIFF
--- a/Cake.Recipe/Content/testing.cake
+++ b/Cake.Recipe/Content/testing.cake
@@ -247,7 +247,7 @@ BuildParameters.Tasks.DotNetCoreTestTask = Task("DotNetCore-Test")
             // https://github.com/cake-build/cake/pull/2824
             settings.ToolPath = Context.Tools.Resolve("reportgenerator");
         }
-        ReportGenerator(BuildParameters.Paths.Files.TestCoverageOutputFilePath, BuildParameters.Paths.Directories.TestCoverage, settings);
+        ReportGenerator(coverageFiles, BuildParameters.Paths.Directories.TestCoverage, settings);
     }
 });
 


### PR DESCRIPTION
The coverage report passed to ReportGenerator on .NET Core was using the path only available when running OpenCover during the build process.
This is incorrect, and should have been the all of the files outputted by Coverlet and OpenCover.

*I did not create a issue for this, as coverlet support was first added in upcoming 2.0.0 of Cake.Recipe*