### PR TITLE
(GH-523) Update codecov to latest bug fix release

### DIFF
--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -39,7 +39,7 @@ public static class ToolSettings
     public static string WyamGlobalTool { get; private set; }
 
     public static void SetToolPreprocessorDirectives(
-        string codecovTool = "#tool nuget:?package=codecov&version=1.12.0",
+        string codecovTool = "#tool nuget:?package=codecov&version=1.12.1",
         string coverallsTool = "#tool nuget:?package=coveralls.net&version=0.7.0",
         string gitReleaseManagerTool = "#tool nuget:?package=GitReleaseManager&version=0.11.0",
         string gitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=5.0.1",
@@ -52,7 +52,7 @@ public static class ToolSettings
         string openCoverTool = "#tool nuget:?package=OpenCover&version=4.7.922",
         string reportGeneratorTool = "#tool nuget:?package=ReportGenerator&version=4.6.1",
         string reportUnitTool = "#tool nuget:?package=ReportUnit&version=1.2.1",
-        string codecovGlobalTool = "#tool dotnet:?package=Codecov.Tool&version=1.12.0",
+        string codecovGlobalTool = "#tool dotnet:?package=Codecov.Tool&version=1.12.1",
         string coverallsGlobalTool = "#tool dotnet:?package=coveralls.net&version=1.0.0",
         string gitReleaseManagerGlobalTool = "#tool dotnet:?package=GitReleaseManager.Tool&version=0.11.0",
         string gitVersionGlobalTool = "#tool dotnet:?package=GitVersion.Tool&version=5.3.4",


### PR DESCRIPTION
The current version of codecov-exe is broken when running on windows when running builds for normal msbuild projects.
This pull request updates codecov-exe to the latest bug fix that fixes this issue.
