### PR TITLE
(maint) Update internals to remove duplication of code

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -2,7 +2,7 @@
 // ADDINS
 ///////////////////////////////////////////////////////////////////////////////
 
-#addin nuget:?package=Cake.Codecov&version=0.8.0
+#addin nuget:?package=Cake.Codecov&version=0.9.1
 #addin nuget:?package=Cake.Coveralls&version=0.10.2
 #addin nuget:?package=Cake.Coverlet&version=2.4.2
 #addin nuget:?package=Cake.Email&version=0.9.2&loaddependencies=true // loading dependencies is important to ensure Cake.Email.Common is loaded as well

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -481,10 +481,8 @@ public class Builder
                 BuildParameters.Tasks.BuildTask.IsDependentOn("Transifex-Pull-Translations");
             }
             BuildParameters.Tasks.TestTask.IsDependentOn("Test-NUnit");
-            BuildParameters.Tasks.TestTask.IsDependentOn("Test-xUnit");
             BuildParameters.Tasks.TestTask.IsDependentOn("Test-MSTest");
-            BuildParameters.Tasks.TestTask.IsDependentOn("Test-VSTest");
-            BuildParameters.Tasks.InstallOpenCoverTask.IsDependentOn("Install-ReportUnit");
+            BuildParameters.Tasks.TestTask.IsDependentOn("Generate-FriendlyTestReport");
         }
         else
         {
@@ -493,8 +491,8 @@ public class Builder
                 BuildParameters.Tasks.DotNetCoreBuildTask.IsDependentOn("Transifex-Pull-Translations");
             }
             BuildParameters.Tasks.TestTask.IsDependentOn(prefix + "Test");
-            BuildParameters.Tasks.InstallOpenCoverTask.IsDependentOn("Install-ReportGenerator");
             BuildParameters.Tasks.PackageTask.IsDependentOn(prefix + "Pack");
         }
+        BuildParameters.Tasks.InstallOpenCoverTask.IsDependentOn("Install-ReportGenerator");
     }
 }

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -16,63 +16,8 @@ public bool IsSupportedCakeVersion(string supportedVersion, string currentVersio
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// SETUP / TEARDOWN
+// TEARDOWN
 ///////////////////////////////////////////////////////////////////////////////
-
-#if !CUSTOM_VERSIONING
-Setup<BuildVersion>(context =>
-{
-    BuildVersion buildVersion = null;
-
-    RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitVersionGlobalTool : ToolSettings.GitVersionTool, () => {
-        buildVersion = BuildVersion.CalculatingSemanticVersion(
-                context: Context
-            );
-        });
-
-    Information("Building version {0} of " + BuildParameters.Title + " ({1}, {2}) using version {3} of Cake, and version {4} of Cake.Recipe. (IsTagged: {5})",
-        buildVersion.SemVersion,
-        BuildParameters.Configuration,
-        BuildParameters.Target,
-        buildVersion.CakeVersion,
-        BuildMetaData.Version,
-        BuildParameters.IsTagged);
-
-    if (!IsSupportedCakeVersion(BuildMetaData.CakeVersion, buildVersion.CakeVersion))
-    {
-        if (HasArgument("ignore-cake-version"))
-        {
-            Warning("Currently running Cake version {0}. This version is not supported together with Cake.Recipe.", buildVersion.CakeVersion);
-            Warning("--ignore-cake-version Switch was found. Continuing execution of Cake.Recipe.");
-        }
-        else
-        {
-            throw new Exception(string.Format("Cake.Recipe currently only supports building projects using version {0} of Cake.  Please update your packages.config file (or whatever method is used to pin to a specific version of Cake) to use this version. Or use the --ignore-cake-version switch if you know what you are doing!", BuildMetaData.CakeVersion));
-        }
-    }
-
-    return buildVersion;
-});
-#endif
-
-Setup<BuildData>(context =>
-{
-    Information(Figlet(BuildParameters.Title));
-
-    Information("Starting Setup...");
-
-    if (BuildParameters.BranchType == BranchType.Master && (context.Log.Verbosity != Verbosity.Diagnostic)) {
-        Information("Increasing verbosity to diagnostic.");
-        context.Log.Verbosity = Verbosity.Diagnostic;
-    }
-
-    // Make sure build and linters run before issues task.
-    IssuesBuildTasks.ReadIssuesTask
-        .IsDependentOn("Build")
-        .IsDependentOn("InspectCode");
-
-    return new BuildData(context);
-});
 
 Teardown<BuildVersion>((context, buildVersion) =>
 {

--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -472,7 +472,6 @@ public class Builder
         BuildParameters.Tasks.UploadCodecovReportTask.IsDependentOn("Test");
         BuildParameters.Tasks.UploadCoverallsReportTask.IsDependentOn("Test");
         BuildParameters.Tasks.ContinuousIntegrationTask.IsDependentOn("Upload-Coverage-Report");
-        BuildParameters.Tasks.InstallReportGeneratorTask.IsDependentOn(prefix + "Build");
 
         if (!isDotNetCoreBuild)
         {
@@ -480,9 +479,17 @@ public class Builder
             {
                 BuildParameters.Tasks.BuildTask.IsDependentOn("Transifex-Pull-Translations");
             }
-            BuildParameters.Tasks.TestTask.IsDependentOn("Test-NUnit");
-            BuildParameters.Tasks.TestTask.IsDependentOn("Test-MSTest");
+
+            BuildParameters.Tasks.TestMSTestTask.IsDependentOn(prefix + "Build");
+            BuildParameters.Tasks.TestNUnitTask.IsDependentOn(prefix + "Build");
+            BuildParameters.Tasks.TestVSTestTask.IsDependentOn(prefix + "Build");
+            BuildParameters.Tasks.TestxUnitTask.IsDependentOn(prefix + "Build");
+            BuildParameters.Tasks.GenerateLocalCoverageReportTask.IsDependentOn("Test-MSTest");
+            BuildParameters.Tasks.GenerateLocalCoverageReportTask.IsDependentOn("Test-NUnit");
+            BuildParameters.Tasks.GenerateLocalCoverageReportTask.IsDependentOn("Test-VSTest");
+            BuildParameters.Tasks.GenerateLocalCoverageReportTask.IsDependentOn("Test-xUnit");
             BuildParameters.Tasks.TestTask.IsDependentOn("Generate-FriendlyTestReport");
+            BuildParameters.Tasks.TestTask.IsDependentOn("Generate-LocalCoverageReport");
         }
         else
         {
@@ -490,9 +497,9 @@ public class Builder
             {
                 BuildParameters.Tasks.DotNetCoreBuildTask.IsDependentOn("Transifex-Pull-Translations");
             }
-            BuildParameters.Tasks.TestTask.IsDependentOn(prefix + "Test");
+            BuildParameters.Tasks.GenerateLocalCoverageReportTask.IsDependentOn(prefix + "Test");
+            BuildParameters.Tasks.TestTask.IsDependentOn("Generate-LocalCoverageReport");
             BuildParameters.Tasks.PackageTask.IsDependentOn(prefix + "Pack");
         }
-        BuildParameters.Tasks.InstallOpenCoverTask.IsDependentOn("Install-ReportGenerator");
     }
 }

--- a/Cake.Recipe/Content/setup.cake
+++ b/Cake.Recipe/Content/setup.cake
@@ -1,0 +1,54 @@
+#if !CUSTOM_VERSIONING
+Setup<BuildVersion>(context =>
+{
+    BuildVersion buildVersion = null;
+
+    RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitVersionGlobalTool : ToolSettings.GitVersionTool, () => {
+        buildVersion = BuildVersion.CalculatingSemanticVersion(
+                context: Context
+            );
+        });
+
+    Information("Building version {0} of " + BuildParameters.Title + " ({1}, {2}) using version {3} of Cake, and version {4} of Cake.Recipe. (IsTagged: {5})",
+        buildVersion.SemVersion,
+        BuildParameters.Configuration,
+        BuildParameters.Target,
+        buildVersion.CakeVersion,
+        BuildMetaData.Version,
+        BuildParameters.IsTagged);
+
+    if (!IsSupportedCakeVersion(BuildMetaData.CakeVersion, buildVersion.CakeVersion))
+    {
+        if (HasArgument("ignore-cake-version"))
+        {
+            Warning("Currently running Cake version {0}. This version is not supported together with Cake.Recipe.", buildVersion.CakeVersion);
+            Warning("--ignore-cake-version Switch was found. Continuing execution of Cake.Recipe.");
+        }
+        else
+        {
+            throw new Exception(string.Format("Cake.Recipe currently only supports building projects using version {0} of Cake.  Please update your packages.config file (or whatever method is used to pin to a specific version of Cake) to use this version. Or use the --ignore-cake-version switch if you know what you are doing!", BuildMetaData.CakeVersion));
+        }
+    }
+
+    return buildVersion;
+});
+#endif
+
+Setup<BuildData>(context =>
+{
+    Information(Figlet(BuildParameters.Title));
+
+    Information("Starting Setup...");
+
+    if (BuildParameters.BranchType == BranchType.Master && (context.Log.Verbosity != Verbosity.Diagnostic)) {
+        Information("Increasing verbosity to diagnostic.");
+        context.Log.Verbosity = Verbosity.Diagnostic;
+    }
+
+    // Make sure build and linters run before issues task.
+    IssuesBuildTasks.ReadIssuesTask
+        .IsDependentOn("Build")
+        .IsDependentOn("InspectCode");
+
+    return new BuildData(context);
+});

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -35,7 +35,6 @@ public class BuildTasks
     public CakeTaskBuilder PublishPreReleasePackagesTask { get; set; }
     public CakeTaskBuilder PublishReleasePackagesTask { get; set; }
     public CakeTaskBuilder InstallReportGeneratorTask { get; set; }
-    public CakeTaskBuilder InstallReportUnitTask { get; set; }
     public CakeTaskBuilder InstallOpenCoverTask { get; set; }
     public CakeTaskBuilder TestNUnitTask { get; set; }
     public CakeTaskBuilder TestxUnitTask { get; set; }
@@ -47,6 +46,7 @@ public class BuildTasks
     public CakeTaskBuilder TransifexSetupTask { get; set; }
     public CakeTaskBuilder DotNetCoreTestTask { get; set; }
     public CakeTaskBuilder IntegrationTestTask { get;set; }
+    public CakeTaskBuilder GenerateFriendlyTestReportTask { get; set; }
     public CakeTaskBuilder TestTask { get; set; }
     public CakeTaskBuilder CleanDocumentationTask { get; set; }
     public CakeTaskBuilder PublishDocumentationTask { get; set; }

--- a/Cake.Recipe/Content/tasks.cake
+++ b/Cake.Recipe/Content/tasks.cake
@@ -34,7 +34,6 @@ public class BuildTasks
     public CakeTaskBuilder CreateNuGetPackagesTask { get; set; }
     public CakeTaskBuilder PublishPreReleasePackagesTask { get; set; }
     public CakeTaskBuilder PublishReleasePackagesTask { get; set; }
-    public CakeTaskBuilder InstallReportGeneratorTask { get; set; }
     public CakeTaskBuilder InstallOpenCoverTask { get; set; }
     public CakeTaskBuilder TestNUnitTask { get; set; }
     public CakeTaskBuilder TestxUnitTask { get; set; }
@@ -47,6 +46,7 @@ public class BuildTasks
     public CakeTaskBuilder DotNetCoreTestTask { get; set; }
     public CakeTaskBuilder IntegrationTestTask { get;set; }
     public CakeTaskBuilder GenerateFriendlyTestReportTask { get; set; }
+    public CakeTaskBuilder GenerateLocalCoverageReportTask { get; set; }
     public CakeTaskBuilder TestTask { get; set; }
     public CakeTaskBuilder CleanDocumentationTask { get; set; }
     public CakeTaskBuilder PublishDocumentationTask { get; set; }


### PR DESCRIPTION
The main purpose of this pull request is to remove as much duplicated code as we can.

The achieve this the following have been done:

1. Moved all setup tasks to its own file. This was done mostly to know in which order they will be executed, in case we need to rely on them.
2. Moved ReportUnit to its own task
3. Moved ReportGenerator to its own task
4. Added a setup task for creating the minimum of common DotNetCoreMSSettings that we need.

Additionally, I updated the reference to Cake.Codecov as the current version passes invalid file path arguments to codecov-exe