### PR TITLE
Update Cake.Issues.Recipe to 0.3.4

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -16,7 +16,7 @@
 #addin nuget:?package=Cake.Twitter&version=0.10.1
 #addin nuget:?package=Cake.Wyam&version=2.2.9
 
-#load nuget:?package=Cake.Issues.Recipe&version=0.3.3
+#load nuget:?package=Cake.Issues.Recipe&version=0.3.4
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));


### PR DESCRIPTION
Update Cake.Issues.Recipe to 0.3.4. This brings support for parsing markdownlint log files, which is required for #240