### PR TITLE
(GH-241) Add ability to break build when issues exist

### DIFF
--- a/Cake.Recipe/Content/analyzing.cake
+++ b/Cake.Recipe/Content/analyzing.cake
@@ -55,6 +55,25 @@ BuildParameters.Tasks.InspectCodeTask = Task("InspectCode")
     })
 );
 
+IssuesBuildTasks.IssuesTask.Does<IssuesData>(data => {
+    if (!BuildParameters.ShouldBreakOnIssues)
+    {
+        return;
+    }
+
+    var query = data.Issues.AsQueryable();
+    if (BuildParameters.IssueBreakPriority > 0)
+    {
+        query = query.Where(i => i.Priority != null && i.Priority >= BuildParameters.IssueBreakPriority);
+    }
+
+    if (query.Count() > 0) {
+        string errorMsg = string.Format("{0} issues was found that needs to be fixed. Breaking build!", query.Count());
+        Error(errorMsg);
+        throw new Exception(errorMsg);
+    }
+});
+
 BuildParameters.Tasks.AnalyzeTask = Task("Analyze")
     .IsDependentOn("DupFinder")
     .IsDependentOn("InspectCode");

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -120,6 +120,9 @@ public static class BuildParameters
     public static FilePath MilestoneReleaseNotesFilePath { get; private set; }
     public static FilePath FullReleaseNotesFilePath { get; private set; }
 
+    public static bool ShouldBreakOnIssues { get; private set; }
+    public static int IssueBreakPriority { get; private set; }
+
     public static bool ShouldRunDupFinder { get; private set; }
     public static bool ShouldRunInspectCode { get; private set; }
     public static bool ShouldRunCoveralls { get; private set; }
@@ -408,7 +411,9 @@ public static class BuildParameters
         string emailSenderAddress = null,
         bool shouldPublishToMyGetWithApiKey = true,
         DirectoryPath restorePackagesDirectory = null,
-        List<PackageSourceData> packageSourceDatas = null
+        List<PackageSourceData> packageSourceDatas = null,
+        bool? shouldBreakOnIssues = null,
+        int issueBreakPriority = 0
         )
     {
         if (context == null)
@@ -549,6 +554,9 @@ public static class BuildParameters
         TreatWarningsAsErrors = treatWarningsAsErrors;
 
         BuildAgentOperatingSystem = context.Environment.Platform.Family;
+
+        ShouldBreakOnIssues = shouldBreakOnIssues ?? !(IsTagged || BranchType == BranchType.Master);
+        IssueBreakPriority = issueBreakPriority;
 
         ShouldPublishToMyGetWithApiKey = shouldPublishToMyGetWithApiKey;
         GitHub = GetGitHubCredentials(context);


### PR DESCRIPTION
This pull request adds the ability to break when there have
been found issues with of the the tools used to identify
those. As well as optionally only take into account
when a issue is of a specified priority.

resolves #241