### PR TITLE
(GH-252) Change xml logger to binary logger when running msbuild

### DIFF
--- a/Cake.Recipe/Content/paths.cake
+++ b/Cake.Recipe/Content/paths.cake
@@ -42,7 +42,7 @@ public class BuildPaths
         // Files
         var testCoverageOutputFilePath = ((DirectoryPath)testCoverageDirectory).CombineWithFilePath("OpenCover.xml");
         var solutionInfoFilePath = ((DirectoryPath)BuildParameters.SourceDirectoryPath).CombineWithFilePath("SolutionInfo.cs");
-        var buildLogFilePath = ((DirectoryPath)buildDirectoryPath).CombineWithFilePath("MsBuild.log");
+        var buildBinLogFilePath = ((DirectoryPath)buildDirectoryPath).CombineWithFilePath("build.binlog");
 
         var repoFilesPaths = new FilePath[] {
             "LICENSE",
@@ -80,8 +80,8 @@ public class BuildPaths
             repoFilesPaths,
             testCoverageOutputFilePath,
             solutionInfoFilePath,
-            buildLogFilePath
-            );
+            buildBinLogFilePath
+        );
 
         return new BuildPaths
         {
@@ -99,20 +99,20 @@ public class BuildFiles
 
     public FilePath SolutionInfoFilePath { get; private set; }
 
-    public FilePath BuildLogFilePath { get; private set; }
+    public FilePath BuildBinLogFilePath { get; private set; }
 
     public BuildFiles(
         ICakeContext context,
         FilePath[] repoFilesPaths,
         FilePath testCoverageOutputFilePath,
         FilePath solutionInfoFilePath,
-        FilePath buildLogFilePath
+        FilePath buildBinLogFilePath
         )
     {
         RepoFilesPaths = Filter(context, repoFilesPaths);
         TestCoverageOutputFilePath = testCoverageOutputFilePath;
         SolutionInfoFilePath = solutionInfoFilePath;
-        BuildLogFilePath = buildLogFilePath;
+        BuildBinLogFilePath = buildBinLogFilePath;
     }
 
     private static FilePath[] Filter(ICakeContext context, FilePath[] files)

--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -24,7 +24,6 @@ public static class ToolSettings
     public static string ReSharperTools { get; private set; }
     public static string KuduSyncTool { get; private set; }
     public static string WyamTool { get; private set; }
-    public static string MSBuildExtensionPackTool { get; private set; }
     public static string XUnitTool { get; private set; }
     public static string NUnitTool { get; private set; }
     public static string OpenCoverTool { get; private set; }
@@ -46,7 +45,6 @@ public static class ToolSettings
         string reSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2019.3.4",
         string kuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.5.3",
         string wyamTool = "#tool nuget:?package=Wyam&version=2.2.9",
-        string msbuildExtensionPackTool = "#tool nuget:?package=MSBuild.Extension.Pack&version=1.9.1",
         string xunitTool = "#tool nuget:?package=xunit.runner.console&version=2.4.1",
         string nunitTool = "#tool nuget:?package=NUnit.ConsoleRunner&version=3.11.1",
         string openCoverTool = "#tool nuget:?package=OpenCover&version=4.7.922",
@@ -67,7 +65,6 @@ public static class ToolSettings
         ReSharperTools = reSharperTools;
         KuduSyncTool = kuduSyncTool;
         WyamTool = wyamTool;
-        MSBuildExtensionPackTool = msbuildExtensionPackTool;
         XUnitTool = xunitTool;
         NUnitTool = nunitTool;
         OpenCoverTool = openCoverTool;


### PR DESCRIPTION
This pull request replaces the already used XMLLogger with a the same BinaryLogger
that is used by Cake.Issues.MSBuild, and makes it equal to the same logging capabilities
as the implementation in pull request #575

resolves #252