### PR TITLE
(maint) Prevent null-reference and sequence empty exceptions to occur

### DIFF
--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -291,7 +291,7 @@ public void CopyBuildOutput(BuildVersion buildVersion)
             }
             else
             {
-                CopyFiles(GetFiles(parsedProject.OutputPaths.First().FullPath + "/**/*"), outputFolder, true);
+                CopyMsBuildProjectOutput(outputFolder, parsedProject);
             }
 
             continue;
@@ -340,14 +340,31 @@ public void CopyMsBuildProjectOutput(DirectoryPath outputBase, CustomProjectPars
         {
             var outputFolder = outputBase.Combine(parsedProject.RootNameSpace).Combine(outputPath.GetDirectoryName());
             EnsureDirectoryExists(outputFolder);
-            CopyFiles(GetFiles(outputPath + "/**/*"), outputFolder, true);
+            var files = GetFiles(outputPath + "/**/*");
+            if (files.Any())
+            {
+                CopyFiles(files, outputFolder, true);
+            }
+            else
+            {
+                Warning("No files was found in the project output directory '{0}'", outputPath);
+            }
         }
     }
     else
     {
         var outputFolder = outputBase.Combine(parsedProject.RootNameSpace);
         EnsureDirectoryExists(outputFolder);
-        CopyFiles(GetFiles(parsedProject.OutputPaths.First().FullPath + "/**/*"), outputFolder, true);
+        var outputPath = parsedProject.OutputPaths.First().FullPath;
+        var files = GetFiles(outputPath + "/**/*");
+        if (files.Any())
+        {
+            CopyFiles(files, outputFolder, true);
+        }
+        else
+        {
+            Warning("No files was found in the project output directory '{0}'", outputPath);
+        }
     }
 }
 

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -520,7 +520,7 @@ public static class BuildParameters
         IsMainRepository = StringComparer.OrdinalIgnoreCase.Equals(string.Concat(repositoryOwner, "/", repositoryName), BuildProvider.Repository.Name);
         IsPublicRepository = isPublicRepository;
 
-        var branchName = BuildProvider.Repository.Branch;
+        var branchName = BuildProvider.Repository.Branch ?? string.Empty; // This is just to prevent any null reference exceptions
         if (StringComparer.OrdinalIgnoreCase.Equals(masterBranchName, branchName))
         {
             BranchType = BranchType.Master;


### PR DESCRIPTION
This pull request has the goal of preventing some of the Null Reference and Sequence is empty exceptions to happen.

I am making sure that in `parameters.cake` the branch name that gets returned from the current CI Provider is set to an empty string in the few cases that the provider returns null.
This is done to prevent the null reference exception to happen when we later checks if the branch name starts with a certain string.

I am also adding an additional check before we copy files in `build.cake` to ensure that we do not get an Empty Sequence exception, which can occur when a project file defines conditional target frameworks (there may be other cases as well).