### PR TITLE
(GH-578) Support building when not using git

### DIFF
--- a/Cake.Recipe/Content/gitversion.cake
+++ b/Cake.Recipe/Content/gitversion.cake
@@ -16,6 +16,29 @@ public class BuildVersion
             throw new ArgumentNullException("context");
         }
 
+        var cakeVersion = typeof(ICakeContext).Assembly.GetName().Version.ToString();
+
+        try
+        {
+            var rootPath = BuildParameters.RootDirectoryPath;
+            rootPath = context.GitFindRootFromPath(rootPath);
+        }
+        catch (LibGit2Sharp.RepositoryNotFoundException rnfe)
+        {
+            context.Warning("Unable to locate git repository, so GitVersion can't be executed, returning default version numbers...");
+
+            return new BuildVersion
+            {
+                Version = "0.1.0",
+                SemVersion = "0.1.0-alpha.0",
+                Milestone = "0.1.0",
+                CakeVersion = cakeVersion,
+                InformationalVersion = "0.1.0-alpha.0+Branch.develop.Sha.528f9bf572a52f0660cbe3f4d109599eab1e9866",
+                FullSemVersion = "0.1.0-alpha.0",
+                AssemblySemVer = "0.1.0.o"
+            };
+        }
+
         string version = null;
         string semVersion = null;
         string milestone = null;
@@ -88,8 +111,6 @@ public class BuildVersion
             informationalVersion = assemblyInfo.AssemblyInformationalVersion;
             milestone = string.Concat(version);
         }
-
-        var cakeVersion = typeof(ICakeContext).Assembly.GetName().Version.ToString();
 
         return new BuildVersion
         {


### PR DESCRIPTION
i.e. when the repository hasn't been cloned, but rather downloaded as a
zip file.

When in this situation, default to some sensible values.

Fixes #578 