### PR TITLE
(maint) Updated build providers to store codecov tokenless support

### DIFF
--- a/Cake.Recipe/Content/appveyor.cake
+++ b/Cake.Recipe/Content/appveyor.cake
@@ -84,6 +84,8 @@ public class AppVeyorBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
+    public bool SupportsTokenlessCodecov { get; } = true;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "APPVEYOR_API_URL",
         "APPVEYOR_BUILD_FOLDER",

--- a/Cake.Recipe/Content/azurepipelines.cake
+++ b/Cake.Recipe/Content/azurepipelines.cake
@@ -72,6 +72,8 @@ public class AzurePipelinesBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
+    public bool SupportsTokenlessCodecov { get; } = true;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "BUILD_BUILDID",
         "BUILD_BUILDNUMBER",

--- a/Cake.Recipe/Content/buildProvider.cake
+++ b/Cake.Recipe/Content/buildProvider.cake
@@ -51,6 +51,8 @@ public interface IBuildProvider
 
     IBuildInfo Build { get; }
 
+    bool SupportsTokenlessCodecov { get; }
+
     IEnumerable<string> PrintVariables { get; }
 
     void UploadArtifact(FilePath file);

--- a/Cake.Recipe/Content/github-actions.cake
+++ b/Cake.Recipe/Content/github-actions.cake
@@ -88,6 +88,8 @@ public class GitHubActionBuildProvider : IBuildProvider
     public IPullRequestInfo PullRequest { get; }
     public IRepositoryInfo Repository { get; }
 
+    public bool SupportsTokenlessCodecov { get; } = true;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "CI",
         "HOME",

--- a/Cake.Recipe/Content/localbuild.cake
+++ b/Cake.Recipe/Content/localbuild.cake
@@ -156,6 +156,8 @@ public class LocalBuildBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
+    public bool SupportsTokenlessCodecov { get; } = false;
+
     public IEnumerable<string> PrintVariables { get; }
 
     private readonly ICakeContext _context;

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -233,9 +233,10 @@ public static class BuildParameters
     {
         get
         {
-            return ShouldRunCodecov &&
-                (!string.IsNullOrEmpty(BuildParameters.Codecov.RepoToken) ||
-                BuildParameters.IsRunningOnAppVeyor || BuildParameters.IsRunningOnTravisCI);
+            return ShouldRunCodecov && (
+                BuildProvider.SupportsTokenlessCodecov ||
+                !string.IsNullOrEmpty(Codecov.RepoToken)
+            );
         }
     }
 

--- a/Cake.Recipe/Content/teamcity.cake
+++ b/Cake.Recipe/Content/teamcity.cake
@@ -82,6 +82,8 @@ public class TeamCityBuildProvider : IBuildProvider
         Repository = new TeamCityRepositoryInfo(teamCity, context);
 
         _teamCity = teamCity;
+
+        SupportsTokenlessCodecov = GetTokenlessSupport(context);
     }
 
     public IRepositoryInfo Repository { get; }
@@ -89,6 +91,8 @@ public class TeamCityBuildProvider : IBuildProvider
     public IPullRequestInfo PullRequest { get; }
 
     public IBuildInfo Build { get; }
+
+    public bool SupportsTokenlessCodecov { get; }
 
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "TEAMCITY_BUILD_BRANCH",
@@ -105,5 +109,26 @@ public class TeamCityBuildProvider : IBuildProvider
     public void UploadArtifact(FilePath file)
     {
         _teamCity.PublishArtifacts(file.FullPath);
+    }
+
+    private static bool GetTokenlessSupport(ICakeContext context)
+    {
+        var neededVariables = new[] {
+            "TEAMCITY_BUILD_BRANCH",
+            "TEAMCITY_BUILD_ID",
+            "TEAMCITY_BUILD_COMMIT",
+            "TEAMCITY_BUILD_REPOSITORY"
+        };
+
+        bool supported = true;
+
+        foreach (var variable in neededVariables)
+        {
+            supported = context.HasEnvironmentVariable(variable);
+            if (!supported)
+                break;
+        }
+
+        return supported;
     }
 }

--- a/Cake.Recipe/Content/travis-ci.cake
+++ b/Cake.Recipe/Content/travis-ci.cake
@@ -60,6 +60,8 @@ public class TravisCiBuildProvider : IBuildProvider
     public IPullRequestInfo PullRequest { get; }
     public IRepositoryInfo Repository { get; }
 
+    public bool SupportsTokenlessCodecov { get; } = true;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "CI",
         "TRAVIS",


### PR DESCRIPTION
This pull request updates the build providers to add a property that defines wether coverage reports can be pushed to codecov.io without using a token.
This is added to make it easier to detect this kind of support, and identify the support when new providers are added or when codecov-exe/codecov.io supports more CI Providers.