### PR TITLE
(GH-583) Correct check for GitHub token vs password for GRM

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -169,8 +169,9 @@ public static class BuildParameters
     {
         get
         {
-            return !string.IsNullOrEmpty(BuildParameters.GitHub.UserName) &&
-                (!string.IsNullOrEmpty(BuildParameters.GitHub.Password) || !string.IsNullOrEmpty(BuildParameters.GitHub.Token));
+            return (!string.IsNullOrEmpty(BuildParameters.GitHub.UserName) &&
+                    !string.IsNullOrEmpty(BuildParameters.GitHub.Password)) ||
+                   !string.IsNullOrEmpty(BuildParameters.GitHub.Token);
         }
     }
 


### PR DESCRIPTION
This Pull Request fixes the incorrect check for usage of a GitHub token when running GitReleaseManager.

This change makes it so that if a GitHub PAT is used, no GitHub username needs to be specified.

fixes #583

also related to issue #452