### PR TITLE
(GH-531) Improve branch detection on github actions

### DIFF
--- a/Cake.Recipe/Content/github-actions.cake
+++ b/Cake.Recipe/Content/github-actions.cake
@@ -33,10 +33,19 @@ public class GitHubActionRepositoryInfo : IRepositoryInfo
             // This trimming is not perfect, as it will remove part of a
             // branch name if the branch name itself contains a '/'
             var tempName = context.EnvironmentVariable("GITHUB_REF");
-            if (!string.IsNullOrEmpty(tempName) && tempName.IndexOf('/') >= 0)
+            const string headPrefix = "refs/heads/";
+            if (!string.IsNullOrEmpty(tempName))
             {
-                tempName = tempName.Substring(tempName.LastIndexOf('/') + 1);
+                if (tempName.StartsWith(headPrefix))
+                {
+                    tempName = tempName.Substring(headPrefix.Length);
+                }
+                else if (tempName.IndexOf('/') >= 0)
+                {
+                    tempName = tempName.Substring(tempName.LastIndexOf('/') + 1);
+                }
             }
+
             Branch = tempName;
         }
         Tag = new GitHubActionTagInfo(context);


### PR DESCRIPTION
During a normal branch build on GitHub actions, the branch reference
is prefixed with 'refs/heads' and should be removed from reference
to get the correct branch name. This pull request makes the change
necessary by checking the tempName if it starts with that string
and remove it if it exist.

This is also considered an enhancement of the code I previously provided
to detect build providers for GitHub Actions (which is currently unreleased code).