### PR TITLE
(GH-597) Add ability to select pre-release or stable release notes

### DIFF
--- a/Cake.Recipe/Content/gitreleasemanager.cake
+++ b/Cake.Recipe/Content/gitreleasemanager.cake
@@ -11,8 +11,12 @@ BuildParameters.Tasks.CreateReleaseNotesTask = Task("Create-Release-Notes")
                 Milestone         = buildVersion.Milestone,
                 Name              = buildVersion.Milestone,
                 TargetCommitish   = BuildParameters.MasterBranchName,
-                Prerelease        = false
+                Prerelease        = context.HasArgument("create-pre-release")
             };
+            if (settings.Prerelease)
+            {
+                settings.TargetCommitish = BuildParameters.BuildProvider.Repository.Branch;
+            }
 
             if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
             {

--- a/Cake.Recipe/Content/gitversion.cake
+++ b/Cake.Recipe/Content/gitversion.cake
@@ -118,7 +118,7 @@ public class BuildVersion
         {
             Version = version,
             SemVersion = semVersion?.ToLowerInvariant(),
-            Milestone = milestone,
+            Milestone = BuildParameters.IsTagged || context.HasArgument("create-pre-release") ? milestone : version,
             CakeVersion = cakeVersion,
             InformationalVersion = informationalVersion?.ToLowerInvariant(),
             FullSemVersion = fullSemVersion?.ToLowerInvariant(),

--- a/docs/input/docs/usage/create-pre-release.md
+++ b/docs/input/docs/usage/create-pre-release.md
@@ -24,8 +24,8 @@ This will allow the version to be calculated correctly by using [GitVersion](htt
 4. Make sure that you have the following environment variables set in your local development environment:
    - [GITHUB_TOKEN](../fundamentals/environment-variables#github_token)
 5. Create a GitHub release draft by running:
-   - On Windows: `.\build.ps1 -target releasenotes`
-   - On MacOS/Linux`./build.sh --target=releasenotes`
+   - On Windows: `.\build.ps1 --target=releasenotes --create-pre-release`
+   - On MacOS/Linux`./build.sh --target=releasenotes --create-pre-release`
 6. Check the generated release notes and make required manual changes.
 7. Publish the draft release on GitHub.
 

--- a/docs/input/docs/usage/create-pre-release.md
+++ b/docs/input/docs/usage/create-pre-release.md
@@ -1,13 +1,16 @@
 ---
-Order: 10
-Title: How to create a stable release
+Order: 11
+Title: How to create a pre release (unstable release)
 ---
 
-This document describes the suggested steps to release a new stable version using the `Cake.Recipe` script.
+This document describes the suggested steps to release a new pre-release version using the `Cake.Recipe` script.
 
 :::{.alert .alert-info}
 Please note that the following steps assume you're using `Cake.Recipe` on GitHub and with a GitFlow workflow.
 Both are not requirements though and you can adopt the steps to other environments.
+
+The process of creating pre-release versions are almost identical to the process of creating stable releases
+which are documented [here](create-release){.alert-link}.
 :::
 
 :::{.alert .alert-warning}
@@ -15,7 +18,7 @@ Remember to enable the build parameter named `shouldRunGitVersion` when running 
 This will allow the version to be calculated correctly by using [GitVersion](https://github.com/GitTools/GitVersion){.alert-link}.
 :::
 
-1. Create a release branch (eg. release/1.2.3).
+1. Create the branch where you want the drafted release notes to be based off (recommended to use release/hotfix branches for beta releases).
 2. Make sure that a GitHub milestone exists for this release.
 3. Make sure there were issues for all changes with the appropriate labels and the correct milestone set.
 4. Make sure that you have the following environment variables set in your local development environment:
@@ -24,7 +27,6 @@ This will allow the version to be calculated correctly by using [GitVersion](htt
    - On Windows: `.\build.ps1 -target releasenotes`
    - On MacOS/Linux`./build.sh --target=releasenotes`
 6. Check the generated release notes and make required manual changes.
-7. If release is ready finish release (merge back into `master` and `develop`) but don't tag the release yet.
-8. Publish the draft release on GitHub.
+7. Publish the draft release on GitHub.
 
 The last step will tag the release and trigger another build including the publishing. The build will automatically publish the build artifacts to the GitHub release, publish to NuGet and notify about the new release through Twitter and Gitter, based on your specific settings.

--- a/docs/input/docs/usage/creating-release.md
+++ b/docs/input/docs/usage/creating-release.md
@@ -21,7 +21,7 @@ This will allow the version to be calculated correctly by using [GitVersion](htt
 4. Make sure that you have the following environment variables set in your local development environment:
    - [GITHUB_TOKEN](../fundamentals/environment-variables#github_token)
 5. Create a GitHub release draft by running:
-   - On Windows: `.\build.ps1 -target releasenotes`
+   - On Windows: `.\build.ps1 --target=releasenotes`
    - On MacOS/Linux`./build.sh --target=releasenotes`
 6. Check the generated release notes and make required manual changes.
 7. If release is ready finish release (merge back into `master` and `develop`) but don't tag the release yet.


### PR DESCRIPTION
This allows an argument called 'create-pre-release' to be used when calling the cake build script for specifically setting the milestone to the generated SemVer version, instead of a stable version. On tagged releases this should always be the SemVer version no matter what is used.

resolves #597