### PR TITLE
(GH-598) Allow users to disable or override target framework path

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -134,6 +134,7 @@ public static class BuildParameters
     public static bool ShouldDocumentSourceFiles { get; private set; }
     public static bool ShouldRunIntegrationTests { get; private set; }
     public static bool ShouldRunGitVersion { get; private set; }
+    public static bool ShouldUseTargetFrameworkPath { get; private set; }
     public static bool ShouldUseDeterministicBuilds
     {
         get
@@ -383,6 +384,7 @@ public static class BuildParameters
         bool shouldBuildNugetSourcePackage = false,
         bool shouldRunIntegrationTests = false,
         bool? shouldRunGitVersion = null,
+        bool shouldUseTargetFrameworkPath = true,
         bool? transifexEnabled = null,
         TransifexMode transifexPullMode = TransifexMode.OnlyTranslated,
         int transifexPullPercentage = 60,
@@ -473,6 +475,7 @@ public static class BuildParameters
         ShouldBuildNugetSourcePackage = shouldBuildNugetSourcePackage;
         ShouldRunGitVersion = shouldRunGitVersion ?? BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows;
         _shouldUseDeterministicBuilds = shouldUseDeterministicBuilds;
+        ShouldUseTargetFrameworkPath = shouldUseTargetFrameworkPath;
 
         MilestoneReleaseNotesFilePath = milestoneReleaseNotesFilePath ?? RootDirectoryPath.CombineWithFilePath("CHANGELOG.md");
         FullReleaseNotesFilePath = fullReleaseNotesFilePath ?? RootDirectoryPath.CombineWithFilePath("ReleaseNotes.md");

--- a/Cake.Recipe/Content/setup.cake
+++ b/Cake.Recipe/Content/setup.cake
@@ -68,7 +68,7 @@ Setup<DotNetCoreMSBuildSettings>(context =>
     {
         settings.WithProperty("ContinuousIntegrationBuild", "true");
     }
-    if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
+    if (BuildParameters.ShouldUseTargetFrameworkPath && BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
     {
         // This needs to be updated when/if we ever starts supporting Cake .NET Core edition.
         var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";

--- a/Cake.Recipe/Content/setup.cake
+++ b/Cake.Recipe/Content/setup.cake
@@ -70,11 +70,8 @@ Setup<DotNetCoreMSBuildSettings>(context =>
     }
     if (BuildParameters.ShouldUseTargetFrameworkPath && BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
     {
-        // This needs to be updated when/if we ever starts supporting Cake .NET Core edition.
-        var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";
-
-        context.Information("Will use FrameworkPathOverride={0} on .NET Core build related tasks since not building on Windows.", frameworkPathOverride);
-        settings.WithProperty("FrameworkPathOverride", frameworkPathOverride);
+        context.Information("Will use FrameworkPathOverride={0} on .NET Core build related tasks since not building on Windows.", ToolSettings.TargetFrameworkPathOverride);
+        settings.WithProperty("FrameworkPathOverride", ToolSettings.TargetFrameworkPathOverride);
     }
 
     return settings;

--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -16,6 +16,7 @@ public static class ToolSettings
     public static MSBuildToolVersion BuildMSBuildToolVersion { get; private set; }
     public static int MaxCpuCount { get; private set; }
     public static DirectoryPath OutputDirectory { get; private set; }
+    public static string TargetFrameworkPathOverride { get; private set; }
 
     public static string CodecovTool { get; private set; }
     public static string CoverallsTool { get; private set; }
@@ -94,6 +95,7 @@ public static class ToolSettings
         MSBuildToolVersion buildMSBuildToolVersion = MSBuildToolVersion.Default,
         int? maxCpuCount = null,
         DirectoryPath outputDirectory = null,
+        DirectoryPath targetFrameworkPathOverride = null,
         string[] dupFinderExcludeFilesByStartingCommentSubstring = null,
         int? dupFinderDiscardCost = null,
         bool? dupFinderThrowExceptionOnFindingDuplicates = null
@@ -119,5 +121,22 @@ public static class ToolSettings
         BuildMSBuildToolVersion = buildMSBuildToolVersion;
         MaxCpuCount = maxCpuCount ?? 0;
         OutputDirectory = outputDirectory;
+        if (BuildParameters.ShouldUseTargetFrameworkPath && targetFrameworkPathOverride == null)
+        {
+            if (context.Environment.Runtime.IsCoreClr)
+            {
+                var path = context.Tools.Resolve("mono").GetDirectory();
+                path = path.Combine("../lib/mono/4.5");
+                TargetFrameworkPathOverride = path.FullPath + "/";
+            }
+            else
+            {
+                TargetFrameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";
+            }
+        }
+        else
+        {
+            TargetFrameworkPathOverride = targetFrameworkPathOverride?.FullPath;
+        }
     }
 }


### PR DESCRIPTION
In some cases, there is no need to use the TargetFrameworkOverridePath when building .NET Full Framework using .NET Core. This is especially true if the user already references the needed reference assemblies provided by Microsoft (which will also be the default in .NET Core 5.x).

In other cases, we may resolve the wrong path to the mono library directory (especialy in cases where a custom directory is used), so allowing users to override the directory used is also useful.

resolves #598