### PR TITLE
(GH-603) Turn on GitVersion by default

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -383,7 +383,7 @@ public static class BuildParameters
         bool shouldRunDotNetCorePack = false,
         bool shouldBuildNugetSourcePackage = false,
         bool shouldRunIntegrationTests = false,
-        bool? shouldRunGitVersion = null,
+        bool shouldRunGitVersion = true,
         bool shouldUseTargetFrameworkPath = true,
         bool? transifexEnabled = null,
         TransifexMode transifexPullMode = TransifexMode.OnlyTranslated,
@@ -473,7 +473,7 @@ public static class BuildParameters
         ShouldRunCodecov = shouldRunCodecov;
         ShouldRunDotNetCorePack = shouldRunDotNetCorePack;
         ShouldBuildNugetSourcePackage = shouldBuildNugetSourcePackage;
-        ShouldRunGitVersion = shouldRunGitVersion ?? BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows;
+        ShouldRunGitVersion = shouldRunGitVersion;
         _shouldUseDeterministicBuilds = shouldUseDeterministicBuilds;
         ShouldUseTargetFrameworkPath = shouldUseTargetFrameworkPath;
 

--- a/docs/input/docs/usage/create-pre-release.md
+++ b/docs/input/docs/usage/create-pre-release.md
@@ -13,11 +13,6 @@ The process of creating pre-release versions are almost identical to the process
 which are documented [here](create-release){.alert-link}.
 :::
 
-:::{.alert .alert-warning}
-Remember to enable the build parameter named `shouldRunGitVersion` when running these steps on Unix platforms.
-This will allow the version to be calculated correctly by using [GitVersion](https://github.com/GitTools/GitVersion){.alert-link}.
-:::
-
 1. Create the branch where you want the drafted release notes to be based off (recommended to use release/hotfix branches for beta releases).
 2. Make sure that a GitHub milestone exists for this release.
 3. Make sure there were issues for all changes with the appropriate labels and the correct milestone set.

--- a/docs/input/docs/usage/creating-release.md
+++ b/docs/input/docs/usage/creating-release.md
@@ -10,11 +10,6 @@ Please note that the following steps assume you're using `Cake.Recipe` on GitHub
 Both are not requirements though and you can adopt the steps to other environments.
 :::
 
-:::{.alert .alert-warning}
-Remember to enable the build parameter named `shouldRunGitVersion` when running these steps on Unix platforms.
-This will allow the version to be calculated correctly by using [GitVersion](https://github.com/GitTools/GitVersion){.alert-link}.
-:::
-
 1. Create a release branch (eg. release/1.2.3).
 2. Make sure that a GitHub milestone exists for this release.
 3. Make sure there were issues for all changes with the appropriate labels and the correct milestone set.

--- a/recipe.cake
+++ b/recipe.cake
@@ -15,8 +15,7 @@ BuildParameters.SetParameters(context: Context,
                             title: "Cake.Recipe",
                             repositoryOwner: "cake-contrib",
                             repositoryName: "Cake.Recipe",
-                            appVeyorAccountName: "cakecontrib",
-                            shouldRunGitVersion: true);
+                            appVeyorAccountName: "cakecontrib");
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
GitVersion now is capable of running everywhere, so let's enable it by
default.

Fixes #603