### PR TITLE
(GH-599) Add preferred CI system

### DIFF
--- a/Cake.Recipe/Content/appveyor.cake
+++ b/Cake.Recipe/Content/appveyor.cake
@@ -86,6 +86,8 @@ public class AppVeyorBuildProvider : IBuildProvider
 
     public bool SupportsTokenlessCodecov { get; } = true;
 
+    public BuildProviderType Type { get; } = BuildProviderType.AppVeyor;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "APPVEYOR_API_URL",
         "APPVEYOR_BUILD_FOLDER",

--- a/Cake.Recipe/Content/azurepipelines.cake
+++ b/Cake.Recipe/Content/azurepipelines.cake
@@ -74,6 +74,8 @@ public class AzurePipelinesBuildProvider : IBuildProvider
 
     public bool SupportsTokenlessCodecov { get; } = true;
 
+    public BuildProviderType Type { get; } = BuildProviderType.AzurePipelines;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "BUILD_BUILDID",
         "BUILD_BUILDNUMBER",
@@ -91,6 +93,6 @@ public class AzurePipelinesBuildProvider : IBuildProvider
 
     public void UploadArtifact(FilePath file)
     {
-        _azurePipelines.Commands.UploadArtifact("", file, "artifacts");    
+        _azurePipelines.Commands.UploadArtifact("", file, "artifacts");
     }
 }

--- a/Cake.Recipe/Content/buildProvider.cake
+++ b/Cake.Recipe/Content/buildProvider.cake
@@ -56,6 +56,18 @@ public interface IBuildProvider
     IEnumerable<string> PrintVariables { get; }
 
     void UploadArtifact(FilePath file);
+
+    BuildProviderType Type { get; }
+}
+
+public enum BuildProviderType
+{
+    AzurePipelines,
+    TeamCity,
+    AppVeyor,
+    Travis,
+    GitHubActions,
+    Local
 }
 
 public static IBuildProvider GetBuildProvider(ICakeContext context, BuildSystem buildSystem)

--- a/Cake.Recipe/Content/github-actions.cake
+++ b/Cake.Recipe/Content/github-actions.cake
@@ -95,6 +95,8 @@ public class GitHubActionBuildProvider : IBuildProvider
 
     public bool SupportsTokenlessCodecov { get; } = true;
 
+    public BuildProviderType Type { get; } = BuildProviderType.GitHubActions;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "CI",
         "HOME",

--- a/Cake.Recipe/Content/gitreleasemanager.cake
+++ b/Cake.Recipe/Content/gitreleasemanager.cake
@@ -41,6 +41,8 @@ BuildParameters.Tasks.ExportReleaseNotesTask = Task("Export-Release-Notes")
     .WithCriteria(() => BuildParameters.IsMainRepository || BuildParameters.PrepareLocalRelease, "Is not main repository, and is not preparing local release")
     .WithCriteria(() => BuildParameters.BranchType == BranchType.Master || BuildParameters.BranchType == BranchType.Release || BuildParameters.BranchType == BranchType.HotFix || BuildParameters.PrepareLocalRelease, "Is not a releasable branch, and is not preparing local release")
     .WithCriteria(() => BuildParameters.IsTagged || BuildParameters.PrepareLocalRelease, "Is not a tagged build, and is not preparing local release")
+    .WithCriteria(() => BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem, "Not running on preferred build agent operating system")
+    .WithCriteria(() => BuildParameters.PreferredBuildProviderType == BuildParameters.BuildProvider.Type, "Not running on preferred build provider type")
     .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {

--- a/Cake.Recipe/Content/localbuild.cake
+++ b/Cake.Recipe/Content/localbuild.cake
@@ -158,6 +158,8 @@ public class LocalBuildBuildProvider : IBuildProvider
 
     public bool SupportsTokenlessCodecov { get; } = false;
 
+    public BuildProviderType Type { get; } = BuildProviderType.Local;
+
     public IEnumerable<string> PrintVariables { get; }
 
     private readonly ICakeContext _context;

--- a/Cake.Recipe/Content/packages.cake
+++ b/Cake.Recipe/Content/packages.cake
@@ -133,6 +133,8 @@ BuildParameters.Tasks.CreateNuGetPackagesTask = Task("Create-NuGet-Packages")
 BuildParameters.Tasks.PublishPreReleasePackagesTask = Task("Publish-PreRelease-Packages")
     .WithCriteria(() => !BuildParameters.IsLocalBuild || BuildParameters.ForceContinuousIntegration, "Skipping because this is a local build, and force isn't being applied")
     .WithCriteria(() => !BuildParameters.IsTagged, "Skipping because current commit is tagged")
+    .WithCriteria(() => BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem, "Not running on preferred build agent operating system")
+    .WithCriteria(() => BuildParameters.PreferredBuildProviderType == BuildParameters.BuildProvider.Type, "Not running on preferred build provider type")
     .IsDependentOn("Package")
     .Does(() =>
 {
@@ -153,6 +155,8 @@ BuildParameters.Tasks.PublishPreReleasePackagesTask = Task("Publish-PreRelease-P
 BuildParameters.Tasks.PublishReleasePackagesTask = Task("Publish-Release-Packages")
     .WithCriteria(() => !BuildParameters.IsLocalBuild || BuildParameters.ForceContinuousIntegration, "Skipping because this is a local build, and force isn't being applied")
     .WithCriteria(() => BuildParameters.IsTagged, "Skipping because current commit is not tagged")
+    .WithCriteria(() => BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem, "Not running on preferred build agent operating system")
+    .WithCriteria(() => BuildParameters.PreferredBuildProviderType == BuildParameters.BuildProvider.Type, "Not running on preferred build provider type")
     .IsDependentOn("Package")
     .Does(() =>
 {

--- a/Cake.Recipe/Content/teamcity.cake
+++ b/Cake.Recipe/Content/teamcity.cake
@@ -92,6 +92,8 @@ public class TeamCityBuildProvider : IBuildProvider
 
     public bool SupportsTokenlessCodecov { get; } = false;
 
+    public BuildProviderType Type { get; } = BuildProviderType.TeamCity;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "TEAMCITY_BUILD_BRANCH",
         "TEAMCITY_BUILD_COMMIT",

--- a/Cake.Recipe/Content/travis-ci.cake
+++ b/Cake.Recipe/Content/travis-ci.cake
@@ -62,6 +62,8 @@ public class TravisCiBuildProvider : IBuildProvider
 
     public bool SupportsTokenlessCodecov { get; } = true;
 
+    public BuildProviderType Type { get; } = BuildProviderType.Travis;
+
     public IEnumerable<string> PrintVariables { get; } = new[] {
         "CI",
         "TRAVIS",


### PR DESCRIPTION
This will allow control over which combination of Operating System and
CI platform should be used when publishing artifacts, etc.  The default
will be AppVeyor and Windows.

Fixes #599 