### PR TITLE
(GH-598) Fix null exception happening on windows

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -382,7 +382,7 @@ public static class BuildParameters
         bool shouldBuildNugetSourcePackage = false,
         bool shouldRunIntegrationTests = false,
         bool shouldCalculateVersion = true,
-        bool shouldUseTargetFrameworkPath = true,
+        bool? shouldUseTargetFrameworkPath = null,
         bool? transifexEnabled = null,
         TransifexMode transifexPullMode = TransifexMode.OnlyTranslated,
         int transifexPullPercentage = 60,
@@ -478,7 +478,7 @@ public static class BuildParameters
         ShouldBuildNugetSourcePackage = shouldBuildNugetSourcePackage;
         ShouldCalculateVersion = shouldCalculateVersion;
         _shouldUseDeterministicBuilds = shouldUseDeterministicBuilds;
-        ShouldUseTargetFrameworkPath = shouldUseTargetFrameworkPath;
+        ShouldUseTargetFrameworkPath = shouldUseTargetFrameworkPath ?? !context.IsRunningOnWindows();
 
         MilestoneReleaseNotesFilePath = milestoneReleaseNotesFilePath ?? RootDirectoryPath.CombineWithFilePath("CHANGELOG.md");
         FullReleaseNotesFilePath = fullReleaseNotesFilePath ?? RootDirectoryPath.CombineWithFilePath("ReleaseNotes.md");

--- a/Cake.Recipe/Content/setup.cake
+++ b/Cake.Recipe/Content/setup.cake
@@ -68,7 +68,7 @@ Setup<DotNetCoreMSBuildSettings>(context =>
     {
         settings.WithProperty("ContinuousIntegrationBuild", "true");
     }
-    if (BuildParameters.ShouldUseTargetFrameworkPath && BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
+    if (BuildParameters.ShouldUseTargetFrameworkPath)
     {
         context.Information("Will use FrameworkPathOverride={0} on .NET Core build related tasks since not building on Windows.", ToolSettings.TargetFrameworkPathOverride);
         settings.WithProperty("FrameworkPathOverride", ToolSettings.TargetFrameworkPathOverride);


### PR DESCRIPTION
A null exception happens when running on windows,
under cake .net core and mono not being installed.
This commit fixes that issues to only set
shouldUseFrameworkPath to true when running
on Unix.

This pr also removes the check for windows platform in the setup stage, as the only way this will run on windows is if the user have specifically set shouldUseFrameworkPath to true.
