### PR TITLE
Update to Cake.Issues.Recipe 0.4.0

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -21,7 +21,7 @@
 #addin nuget:?package=Cake.Twitter&version=0.10.1
 #addin nuget:?package=Cake.Wyam&version=2.2.9
 
-#load nuget:?package=Cake.Issues.Recipe&version=0.4.0-beta0001&prerelease
+#load nuget:?package=Cake.Issues.Recipe&version=0.4.0
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));

--- a/Cake.Recipe/Content/analyzing.cake
+++ b/Cake.Recipe/Content/analyzing.cake
@@ -5,10 +5,12 @@ BuildParameters.Tasks.DupFinderTask = Task("DupFinder")
     .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping due to not running on Windows")
     .WithCriteria(() => BuildParameters.ShouldRunDupFinder, "Skipping because DupFinder has been disabled")
     .Does(() => RequireTool(ToolSettings.ReSharperTools, () => {
+        var dupFinderLogFilePath = BuildParameters.Paths.Directories.DupFinderTestResults.CombineWithFilePath("dupfinder.xml");
+
         var settings = new DupFinderSettings() {
             ShowStats = true,
             ShowText = true,
-            OutputFile = BuildParameters.Paths.Directories.DupFinderTestResults.CombineWithFilePath("dupfinder.xml"),
+            OutputFile = dupFinderLogFilePath,
             ExcludeCodeRegionsByNameSubstring = new string [] { "DupFinder Exclusion" },
             ThrowExceptionOnFindingDuplicates = ToolSettings.DupFinderThrowExceptionOnFindingDuplicates ?? true
         };
@@ -29,6 +31,9 @@ BuildParameters.Tasks.DupFinderTask = Task("DupFinder")
         }
 
         DupFinder(BuildParameters.SolutionFilePath, settings);
+
+        // Pass path to dupFinder log file to Cake.Issues.Recipe
+        IssuesParameters.InputFiles.DupFinderLogFilePath = dupFinderLogFilePath;
     })
 );
 


### PR DESCRIPTION
Update Cake.Issues.Recipe to final version of 0.4.0, which brings support for dupFinder issues and file linking (so that file names are linked to source code if it is hosted on either GitHub or Azure Repos).