### PR TITLE
(GH-626) Add restoring of nuget if none is found

### DIFF
--- a/Cake.Recipe/Content/build.cake
+++ b/Cake.Recipe/Content/build.cake
@@ -136,13 +136,14 @@ BuildParameters.Tasks.RestoreTask = Task("Restore")
     .Does(() =>
 {
     Information("Restoring {0}...", BuildParameters.SolutionFilePath);
-
-    NuGetRestore(
-        BuildParameters.SolutionFilePath,
-        new NuGetRestoreSettings
-        {
-            Source = BuildParameters.NuGetSources
-        });
+    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+        NuGetRestore(
+            BuildParameters.SolutionFilePath,
+            new NuGetRestoreSettings
+            {
+                Source = BuildParameters.NuGetSources
+            });
+    });
 });
 
 BuildParameters.Tasks.DotNetCoreRestoreTask = Task("DotNetCore-Restore")

--- a/Cake.Recipe/Content/packages.cake
+++ b/Cake.Recipe/Content/packages.cake
@@ -70,18 +70,20 @@ BuildParameters.Tasks.CreateNuGetPackageTask = Task("Create-Nuget-Package")
     if (BuildParameters.NuSpecFilePath != null) {
         EnsureDirectoryExists(BuildParameters.Paths.Directories.NuGetPackages);
 
-        // Create packages.
-        NuGetPack(BuildParameters.NuSpecFilePath, new NuGetPackSettings {
-            Version = buildVersion.SemVersion,
-            OutputDirectory = BuildParameters.Paths.Directories.NuGetPackages,
-            Symbols = BuildParameters.ShouldBuildNugetSourcePackage,
-            NoPackageAnalysis = true,
-            ArgumentCustomization = args => {
-                if (BuildParameters.ShouldBuildNugetSourcePackage)
-                    return args.AppendSwitch("-SymbolPackageFormat", "snupkg");
-                else
-                    return args;
-            }
+        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+            // Create packages.
+            NuGetPack(BuildParameters.NuSpecFilePath, new NuGetPackSettings {
+                Version = buildVersion.SemVersion,
+                OutputDirectory = BuildParameters.Paths.Directories.NuGetPackages,
+                Symbols = BuildParameters.ShouldBuildNugetSourcePackage,
+                NoPackageAnalysis = true,
+                ArgumentCustomization = args => {
+                    if (BuildParameters.ShouldBuildNugetSourcePackage)
+                        return args.AppendSwitch("-SymbolPackageFormat", "snupkg");
+                    else
+                        return args;
+                }
+            });
         });
     }
     else
@@ -109,6 +111,8 @@ BuildParameters.Tasks.CreateNuGetPackagesTask = Task("Create-NuGet-Packages")
     {
         settings.ArgumentCustomization = args => args.AppendSwitch("-SymbolPackageFormat", "snupkg");
     }
+
+    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => { });
 
     foreach (var nuspecFile in nuspecFiles)
     {
@@ -143,7 +147,9 @@ BuildParameters.Tasks.PublishPreReleasePackagesTask = Task("Publish-PreRelease-P
 
     PushChocolateyPackages(Context, false, chocolateySources);
 
-    PushNuGetPackages(Context, false, nugetSources);
+    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+        PushNuGetPackages(Context, false, nugetSources);
+    });
 })
 .OnError(exception =>
 {
@@ -165,7 +171,9 @@ BuildParameters.Tasks.PublishReleasePackagesTask = Task("Publish-Release-Package
 
     PushChocolateyPackages(Context, true, chocolateySources);
 
-    PushNuGetPackages(Context, true, nugetSources);
+    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+        PushNuGetPackages(Context, true, nugetSources);
+    });
 
     BuildParameters.PublishReleasePackagesWasSuccessful = true;
 })

--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -2,6 +2,25 @@
 // TOOLS
 ///////////////////////////////////////////////////////////////////////////////
 
+Action<string, string[], Action> RequireToolNotRegistered = (tool, toolNames, action) => {
+    bool found = false;
+
+    foreach (var name in toolNames)
+    {
+        if (found)
+        {
+            break;
+        }
+        var path = Context.Tools.Resolve(name);
+        found = path != null;
+    }
+
+    if (!found)
+    {
+        RequireTool(tool, action);
+    }
+};
+
 Action<string, Action> RequireTool = (tool, action) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));
     try

--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -26,6 +26,7 @@ public static class ToolSettings
     public static string WyamTool { get; private set; }
     public static string XUnitTool { get; private set; }
     public static string NUnitTool { get; private set; }
+    public static string NuGetTool { get; private set; }
     public static string OpenCoverTool { get; private set; }
     public static string ReportGeneratorTool { get; private set; }
     public static string ReportUnitTool { get; private set; }
@@ -50,6 +51,7 @@ public static class ToolSettings
         string wyamTool = "#tool nuget:?package=Wyam&version=2.2.9",
         string xunitTool = "#tool nuget:?package=xunit.runner.console&version=2.4.1",
         string nunitTool = "#tool nuget:?package=NUnit.ConsoleRunner&version=3.11.1",
+        string nugetTool = "#tool nuget:package=?NuGet.CommandLine&version=5.7.0",
         string openCoverTool = "#tool nuget:?package=OpenCover&version=4.7.922",
         string reportGeneratorTool = "#tool nuget:?package=ReportGenerator&version=4.6.5",
         string reportUnitTool = "#tool nuget:?package=ReportUnit&version=1.2.1",
@@ -72,6 +74,7 @@ public static class ToolSettings
         WyamTool = wyamTool;
         XUnitTool = xunitTool;
         NUnitTool = nunitTool;
+        NuGetTool = nugetTool;
         OpenCoverTool = openCoverTool;
         ReportGeneratorTool = reportGeneratorTool;
         ReportUnitTool = reportUnitTool;


### PR DESCRIPTION
This pull request adds the ability to run cake.recipe and push package even when no local or global nuget executable is available.
This is done by first checking if a nuget executable is available (either with the name nuget, or nuget.exe) and only restore NuGet.CommandLine if no executable was found.

fixes #626