### PR TITLE
(maint) Fix action never getting called when tool already exist

### DIFF
--- a/Cake.Recipe/Content/tools.cake
+++ b/Cake.Recipe/Content/tools.cake
@@ -19,6 +19,10 @@ Action<string, string[], Action> RequireToolNotRegistered = (tool, toolNames, ac
     {
         RequireTool(tool, action);
     }
+    else
+    {
+        action();
+    }
 };
 
 Action<string, Action> RequireTool = (tool, action) => {


### PR DESCRIPTION
The initial pull request that was created to allow running nuget package when nuget isn't installed, mistakenly removed continuing the execution when nuget is available.

This pull request fixes that issue, so we can have nuget packages again.﻿
