### PR TITLE
(maint) Add missing string split options

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Only windows is possible until supported cake version
-        # is bumped to 0.37.0.0+.
-        # See https://github.com/cake-build/cake/issues/2695
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2.2.0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,6 @@
     "vstest",
     "wixproj",
     "xbuild"
-  ]
+  ],
+  "powershell.codeFormatting.addWhitespaceAroundPipe": true
 }

--- a/Cake.Recipe/Content/buildPlatform.cake
+++ b/Cake.Recipe/Content/buildPlatform.cake
@@ -203,7 +203,7 @@ public class LinuxBuildPlatform : BuildPlatform
 
         var lines = System.IO.File.ReadAllLines(file);
         var details = lines.Where(l => !string.IsNullOrEmpty(l))
-            .Select(l => l.Split('='))
+            .Select(l => l.Split(new [] {'=' }, StringSplitOptions.None))
             .Where(s => s.Length == 2)
             .ToDictionary(s => s[0].ToUpperInvariant(), s => s[1]);
 

--- a/Cake.Recipe/Content/email.cake
+++ b/Cake.Recipe/Content/email.cake
@@ -10,7 +10,7 @@ public void SendEmail(string subject, string message, string recipient, string s
 
     // The recipient parameter can contain a single email address or a comma/semi-colon separated list of email addresses
     var recipients = recipient
-        .Split(new[] { ',', ';' })
+        .Split(new[] { ',', ';' }, StringSplitOptions.None)
         .Select(emailAddress => new MailAddress(emailAddress))
         .ToArray();
 

--- a/Cake.Recipe/Content/testing.cake
+++ b/Cake.Recipe/Content/testing.cake
@@ -119,11 +119,11 @@ BuildParameters.Tasks.DotNetCoreTestTask = Task("DotNetCore-Test")
         // It is problematic to merge the reports into one, as such we use a custom directory for coverage results
         CoverletOutputDirectory = BuildParameters.Paths.Directories.TestCoverage.Combine("coverlet"),
         CoverletOutputFormat    = CoverletOutputFormat.opencover,
-        ExcludeByFile           = ToolSettings.TestCoverageExcludeByFile.Split(';').ToList(),
-        ExcludeByAttribute      = ToolSettings.TestCoverageExcludeByAttribute.Split(';').ToList()
+        ExcludeByFile           = ToolSettings.TestCoverageExcludeByFile.Split(new [] {';' }, StringSplitOptions.None).ToList(),
+        ExcludeByAttribute      = ToolSettings.TestCoverageExcludeByAttribute.Split(new [] {';' }, StringSplitOptions.None).ToList()
     };
 
-    foreach (var filter in ToolSettings.TestCoverageFilter.Split(' '))
+    foreach (var filter in ToolSettings.TestCoverageFilter.Split(new [] {' ' }, StringSplitOptions.None))
     {
         if (filter[0] == '+')
         {


### PR DESCRIPTION
Due to a use case not being considered, trailing spaces, multiple spaces and prefixed spaces causes an exception to occur.
This pull request adds a StringSplitOptions.None to all split operations to prevent this from happening.﻿
