### PR TITLE
(GH-581) Remove use of Username/pass for GitHub

### DIFF
--- a/Cake.Recipe/Content/credentials.cake
+++ b/Cake.Recipe/Content/credentials.cake
@@ -1,13 +1,9 @@
 public class GitHubCredentials
 {
-    public string UserName { get; private set; }
-    public string Password { get; private set; }
     public string Token { get; private set; }
 
-    public GitHubCredentials(string userName, string password, string token)
+    public GitHubCredentials(string token)
     {
-        UserName = userName;
-        Password = password;
         Token = token;
     }
 }
@@ -149,10 +145,7 @@ public class WyamCredentials
 
 public static GitHubCredentials GetGitHubCredentials(ICakeContext context)
 {
-    return new GitHubCredentials(
-        context.EnvironmentVariable(Environment.GithubUserNameVariable),
-        context.EnvironmentVariable(Environment.GithubPasswordVariable),
-        context.EnvironmentVariable(Environment.GithubTokenVariable));
+    return new GitHubCredentials(context.EnvironmentVariable(Environment.GithubTokenVariable));
 }
 
 public static EmailCredentials GetEmailCredentials(ICakeContext context)

--- a/Cake.Recipe/Content/environment.cake
+++ b/Cake.Recipe/Content/environment.cake
@@ -1,7 +1,5 @@
 public static class Environment
 {
-    public static string GithubUserNameVariable { get; private set; }
-    public static string GithubPasswordVariable { get; private set; }
     public static string GithubTokenVariable { get; private set; }
     public static string GitterTokenVariable { get; private set; }
     public static string GitterRoomIdVariable { get; private set; }
@@ -26,8 +24,6 @@ public static class Environment
     public static string WyamDeployBranchVariable { get; private set; }
 
     public static void SetVariableNames(
-        string githubUserNameVariable = null,
-        string githubPasswordVariable = null,
         string githubTokenVariable = null,
         string gitterTokenVariable = null,
         string gitterRoomIdVariable = null,
@@ -51,8 +47,6 @@ public static class Environment
         string wyamDeployRemoteVariable = null,
         string wyamDeployBranchVariable = null)
     {
-        GithubUserNameVariable = githubUserNameVariable ?? "GITHUB_USERNAME";
-        GithubPasswordVariable = githubPasswordVariable ?? "GITHUB_PASSWORD";
         GithubTokenVariable = githubTokenVariable ?? "GITHUB_TOKEN";
         GitterTokenVariable = gitterTokenVariable ?? "GITTER_TOKEN";
         GitterRoomIdVariable = gitterRoomIdVariable ?? "GITTER_ROOM_ID";

--- a/Cake.Recipe/Content/gitreleasemanager.cake
+++ b/Cake.Recipe/Content/gitreleasemanager.cake
@@ -18,14 +18,7 @@ BuildParameters.Tasks.CreateReleaseNotesTask = Task("Create-Release-Notes")
                 settings.TargetCommitish = BuildParameters.BuildProvider.Repository.Branch;
             }
 
-            if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
-            {
-                GitReleaseManagerCreate(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, settings);
-            }
-            else
-            {
-                GitReleaseManagerCreate(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, settings);
-            }
+            GitReleaseManagerCreate(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, settings);
         }
         else
         {
@@ -53,26 +46,12 @@ BuildParameters.Tasks.ExportReleaseNotesTask = Task("Export-Release-Notes")
                     TagName         = buildVersion.Milestone
                 };
 
-                if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
-                {
-                    GitReleaseManagerExport(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.MilestoneReleaseNotesFilePath, settings);
-                }
-                else
-                {
-                    GitReleaseManagerExport(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.MilestoneReleaseNotesFilePath, settings);
-                }
+                GitReleaseManagerExport(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.MilestoneReleaseNotesFilePath, settings);
             }
 
             if (BuildParameters.ShouldDownloadFullReleaseNotes)
             {
-                if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
-                {
-                    GitReleaseManagerExport(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.FullReleaseNotesFilePath);
-                }
-                else
-                {
-                    GitReleaseManagerExport(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.FullReleaseNotesFilePath);
-                }
+                GitReleaseManagerExport(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.FullReleaseNotesFilePath);
             }
         }
         else
@@ -93,24 +72,10 @@ BuildParameters.Tasks.PublishGitHubReleaseTask = Task("Publish-GitHub-Release")
                                    GetFiles(BuildParameters.Paths.Directories.NuGetPackages + "/*") +
                                    GetFiles(BuildParameters.Paths.Directories.ChocolateyPackages + "/*"))
             {
-                if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
-                {
-                    GitReleaseManagerAddAssets(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone, package.ToString());
-                }
-                else
-                {
-                    GitReleaseManagerAddAssets(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone, package.ToString());
-                }
+                GitReleaseManagerAddAssets(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone, package.ToString());
             }
 
-            if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
-            {
-                GitReleaseManagerClose(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone);
-            }
-            else
-            {
-                GitReleaseManagerClose(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone);
-            }
+            GitReleaseManagerClose(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, buildVersion.Milestone);
         }
         else
         {
@@ -129,14 +94,7 @@ BuildParameters.Tasks.CreateDefaultLabelsTask = Task("Create-Default-Labels")
     .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {
-            if (!string.IsNullOrEmpty(BuildParameters.GitHub.Token))
-            {
-                GitReleaseManagerLabel(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName);
-            }
-            else
-            {
-                GitReleaseManagerLabel(BuildParameters.GitHub.UserName, BuildParameters.GitHub.Password, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName);
-            }
+            GitReleaseManagerLabel(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName);
         }
         else
         {

--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -169,9 +169,7 @@ public static class BuildParameters
     {
         get
         {
-            return (!string.IsNullOrEmpty(BuildParameters.GitHub.UserName) &&
-                    !string.IsNullOrEmpty(BuildParameters.GitHub.Password)) ||
-                   !string.IsNullOrEmpty(BuildParameters.GitHub.Token);
+            return !string.IsNullOrEmpty(BuildParameters.GitHub.Token);
         }
     }
 

--- a/docs/input/docs/fundamentals/environment-variables.md
+++ b/docs/input/docs/fundamentals/environment-variables.md
@@ -32,14 +32,6 @@ A token will be checked for first, and if not provided, the username and passwor
 In addition to these environment variables being present, and correct, the control variable [shouldPublishToGitHub](./set-parameters#shouldPublishToGitHub) also needs to be set to true.
 :::
 
-### GITHUB_USERNAME
-
-User name of the GitHub account to be used.
-
-### GITHUB_PASSWORD
-
-Password of the GitHub account to be used.
-
 ### GITHUB_TOKEN
 
 The Personal Access Token of the GitHub account to be used.

--- a/docs/input/docs/fundamentals/set-variable-names.md
+++ b/docs/input/docs/fundamentals/set-variable-names.md
@@ -35,14 +35,6 @@ else
 
 The `SetVariableNames` method uses the concept of optional parameters, in fact, all the parameters to the `SetVariableNames` method are optional.  To override a specific environment variable, you need to use a named parameter.  The following is a list of all the named parameters that can be used on the method.
 
-### githubUserNameVariable
-
-Default value: `GITHUB_USERNAME`
-
-### githubPasswordVariable
-
-Default value: `GITHUB_PASSWORD`
-
 ### githubTokenVariable
 
 Default value: `GITHUB_TOKEN`


### PR DESCRIPTION
This is being removed from GitHub itself, so we need to remove it from
Cake.Recipe as well.  The upcoming 2.0.0 is the ideal time to put this
through.

Fixes #581 