### PR TITLE
(docs) Minor fixes to documentation

### DIFF
--- a/docs/input/_Bottom.cshtml
+++ b/docs/input/_Bottom.cshtml
@@ -1,6 +1,7 @@
-<div class="github-button">
-    <a href="https://github.com/cake-contrib/Cake.Recipe" target="_blank"><i class="fa fa-github"></i> GitHub</a>
-</div>
+<a class="github-button" href="https://github.com/cake-contrib/Cake.Recipe" target="_blank">
+    <i class="fa fa-github"></i>
+    GitHub
+</a>
 <script>
     ((window.gitter = {}).chat = {}).options = {
         room: 'cake-contrib/Lobby'

--- a/docs/input/docs/extending/modify-built-in-tasks.md
+++ b/docs/input/docs/extending/modify-built-in-tasks.md
@@ -13,7 +13,7 @@ To clear existing actions from the task call `Tasks.Actions.Clear()` on the refe
 
 ```csharp
 // Clear the InspectCode tasks actions
-BuildParameters.Tasks.InspectCodeTask.Task.Actions.Clear();
+((CakeTask)BuildParameters.Tasks.InspectCodeTask.Task).Actions.Clear();
 ```
 
 New actions, dependencies, criteria, etc. can be added at any time to Cake tasks. You can even have multiple calls to the `.Does(...)` method and each action will be executed.


### PR DESCRIPTION
These fixes include an incorrect documentation of how to override built-in cake tasks, and a minor fix to how the GitHub button is handled.