### PR TITLE
(GH-673) Use .Net Global Tool for ReSharper Tools

### DIFF
--- a/Cake.Recipe/Content/analyzing.cake
+++ b/Cake.Recipe/Content/analyzing.cake
@@ -2,9 +2,9 @@
 // TASK DEFINITIONS
 ///////////////////////////////////////////////////////////////////////////////
 BuildParameters.Tasks.DupFinderTask = Task("DupFinder")
-    .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping due to not running on Windows")
+    .WithCriteria(() => BuildParameters.IsDotNetCoreBuild || BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping due to not running on Windows, or using .Net Global Tools for JetBrains")
     .WithCriteria(() => BuildParameters.ShouldRunDupFinder, "Skipping because DupFinder has been disabled")
-    .Does(() => RequireTool(ToolSettings.ReSharperTools, () => {
+    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.ReSharperGlobalTools : ToolSettings.ReSharperTools, () => {
         var dupFinderLogFilePath = BuildParameters.Paths.Directories.DupFinderTestResults.CombineWithFilePath("dupfinder.xml");
 
         var settings = new DupFinderSettings() {
@@ -14,6 +14,18 @@ BuildParameters.Tasks.DupFinderTask = Task("DupFinder")
             ExcludeCodeRegionsByNameSubstring = new string [] { "DupFinder Exclusion" },
             ThrowExceptionOnFindingDuplicates = ToolSettings.DupFinderThrowExceptionOnFindingDuplicates ?? true
         };
+
+        // Workaround until 1.0.0+ version of cake is released
+        if (BuildParameters.IsDotNetCoreBuild && BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows)
+        {
+            settings.ToolPath = Context.Tools.Resolve("jb.exe");
+            settings.ArgumentCustomization = args => args.Prepend("dupfinder");
+        }
+        else if(BuildParameters.IsDotNetCoreBuild)
+        {
+            settings.ToolPath = Context.Tools.Resolve("jb");
+            settings.ArgumentCustomization = args => args.Prepend("dupfinder");
+        }
 
         if (ToolSettings.DupFinderExcludePattern != null)
         {
@@ -38,15 +50,27 @@ BuildParameters.Tasks.DupFinderTask = Task("DupFinder")
 );
 
 BuildParameters.Tasks.InspectCodeTask = Task("InspectCode")
-    .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping due to not running on Windows")
+    .WithCriteria(() => BuildParameters.IsDotNetCoreBuild || BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping due to not running on Windows, or using .Net Global Tools for JetBrains")
     .WithCriteria(() => BuildParameters.ShouldRunInspectCode, "Skipping because InspectCode has been disabled")
-    .Does<BuildData>(data => RequireTool(ToolSettings.ReSharperTools, () => {
+    .Does<BuildData>(data => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.ReSharperGlobalTools : ToolSettings.ReSharperTools, () => {
         var inspectCodeLogFilePath = BuildParameters.Paths.Directories.InspectCodeTestResults.CombineWithFilePath("inspectcode.xml");
 
         var settings = new InspectCodeSettings() {
             SolutionWideAnalysis = true,
             OutputFile = inspectCodeLogFilePath
         };
+
+        // Workaround until 1.0.0+ version of cake is released
+        if (BuildParameters.IsDotNetCoreBuild && BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows)
+        {
+            settings.ToolPath = Context.Tools.Resolve("jb.exe");
+            settings.ArgumentCustomization = args => args.Prepend("inspectcode");
+        }
+        else if(BuildParameters.IsDotNetCoreBuild)
+        {
+            settings.ToolPath = Context.Tools.Resolve("jb");
+            settings.ArgumentCustomization = args => args.Prepend("inspectcode");
+        }
 
         if (FileExists(BuildParameters.SourceDirectoryPath.CombineWithFilePath(BuildParameters.ResharperSettingsFileName)))
         {

--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -38,6 +38,7 @@ public static class ToolSettings
     public static string ReportGeneratorGlobalTool { get; private set; }
     public static string WyamGlobalTool { get; private set; }
     public static string KuduSyncGlobalTool { get; private set; }
+    public static string ReSharperGlobalTools { get; private set; }
 
     public static void SetToolPreprocessorDirectives(
         string codecovTool = "#tool nuget:?package=codecov&version=1.12.3",
@@ -62,7 +63,8 @@ public static class ToolSettings
         string reportGeneratorGlobalTool = "#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.6.7",
         string wyamGlobalTool = "#tool dotnet:?package=Wyam.Tool&version=2.2.9",
         // This is using an unofficial build of kudusync so that we can have a .Net Global tool version.  This was generated from this PR: https://github.com/projectkudu/KuduSync.NET/pull/27
-        string kuduSyncGlobalTool = "#tool dotnet:https://www.myget.org/F/cake-contrib/api/v3/index.json?package=KuduSync.Tool&version=1.5.4-g3916ad7218"
+        string kuduSyncGlobalTool = "#tool dotnet:https://www.myget.org/F/cake-contrib/api/v3/index.json?package=KuduSync.Tool&version=1.5.4-g3916ad7218",
+        string resharperGlobalTools = "#tool dotnet:?package=JetBrains.ReSharper.GlobalTools&version=2020.2.2"
     )
     {
         CodecovTool = codecovTool;
@@ -85,6 +87,7 @@ public static class ToolSettings
         CoverallsGlobalTool = coverallsGlobalTool;
         WyamGlobalTool = wyamGlobalTool;
         KuduSyncGlobalTool = kuduSyncGlobalTool;
+        ReSharperGlobalTools = resharperGlobalTools;
     }
 
     public static void SetToolSettings(


### PR DESCRIPTION
This will need changed once upstream support is added into Cake for the
new way of executing DupFinder and InspectCode on non Windows machines.

Fixes #673 