### PR TITLE
(GH-684) parameter ShouldDocumentSourceFiles is no longer dependent …

### DIFF
--- a/Cake.Recipe/Content/parameters.cake
+++ b/Cake.Recipe/Content/parameters.cake
@@ -602,7 +602,7 @@ public static class BuildParameters
                                 BuildParameters.PreferredBuildProviderType == BuildParameters.BuildProvider.Type &&
                                 shouldGenerateDocumentation);
 
-        ShouldDocumentSourceFiles = ShouldGenerateDocumentation && shouldDocumentSourceFiles;
+        ShouldDocumentSourceFiles = shouldDocumentSourceFiles;
 
         ShouldRunIntegrationTests = (((!IsLocalBuild && !IsPullRequest && IsMainRepository) &&
                                         (BuildParameters.BranchType == BranchType.Master || BuildParameters.BranchType == BranchType.Develop || BuildParameters.BranchType == BranchType.Release || BuildParameters.BranchType == BranchType.HotFix) &&


### PR DESCRIPTION
…on ShouldGenerateDocumentation.

fixes #684 

I have not updated the documentation, I feel the current description still fits.