### PR TITLE
Update Cake.Issues.Recipe to 0.4.1

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -21,7 +21,7 @@
 #addin nuget:?package=Cake.Twitter&version=0.10.1
 #addin nuget:?package=Cake.Wyam&version=2.2.9
 
-#load nuget:?package=Cake.Issues.Recipe&version=0.4.0
+#load nuget:?package=Cake.Issues.Recipe&version=0.4.1
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));


### PR DESCRIPTION
Update Cake.Issues.Recipe to 0.4.1, which updates to [Cake.Issues 0.9.1](https://github.com/cake-contrib/Cake.Issues/releases/tag/0.9.1) and [Cake.Issues.PullRequests.AzureDevOps 0.9.1](https://github.com/cake-contrib/Cake.Issues.PullRequests.AzureDevOps/releases/tag/0.9.1).