### PR TITLE
Update Cake.Issues.Recipe to 0.4.3

### DIFF
--- a/Cake.Recipe/Content/addins.cake
+++ b/Cake.Recipe/Content/addins.cake
@@ -21,7 +21,7 @@
 #addin nuget:?package=Cake.Twitter&version=0.10.1
 #addin nuget:?package=Cake.Wyam&version=2.2.9
 
-#load nuget:?package=Cake.Issues.Recipe&version=0.4.2
+#load nuget:?package=Cake.Issues.Recipe&version=0.4.3
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));


### PR DESCRIPTION
Update Cake.Issues.Recipe to 0.4.3. Same feature set as 0.4.2, but uses Cake.Issues.PullRequests.GitHubActions, instead of implementation in Cake.Issues.Recipe itself.