### PR TITLE
(GH-719) Tagged commits on Hotfix branch do not use the correct seman…

### DIFF
--- a/Cake.Recipe/Content/gitversion.cake
+++ b/Cake.Recipe/Content/gitversion.cake
@@ -118,7 +118,7 @@ public class BuildVersion
         return new BuildVersion
         {
             Version = version,
-            SemVersion = (BuildParameters.BranchType == BranchType.HotFix || BuildParameters.BranchType == BranchType.Release && !BuildParameters.IsTagged) ? uniqueSemVersion?.ToLowerInvariant() : semVersion?.ToLowerInvariant(),
+            SemVersion = ((BuildParameters.BranchType == BranchType.HotFix || BuildParameters.BranchType == BranchType.Release) && !BuildParameters.IsTagged) ? uniqueSemVersion?.ToLowerInvariant() : semVersion?.ToLowerInvariant(),
             Milestone = BuildParameters.IsTagged || context.HasArgument("create-pre-release") ? milestone : version,
             CakeVersion = cakeVersion,
             InformationalVersion = informationalVersion?.ToLowerInvariant(),


### PR DESCRIPTION
…tic version number

Hotfix and Release branches should use the unique semantic version
number - implemented in (GH-616).

To fully implement as intended, the logic for applying the correct
semantic version format needs to ensure that the 'is tagged' check
is applied to each of the branch types.