### PR TITLE
(GH-700) renamed GITHUB_TOKEN to GITHUB_PAT

### DIFF
--- a/Cake.Recipe/Content/credentials.cake
+++ b/Cake.Recipe/Content/credentials.cake
@@ -145,7 +145,18 @@ public class WyamCredentials
 
 public static GitHubCredentials GetGitHubCredentials(ICakeContext context)
 {
-    return new GitHubCredentials(context.EnvironmentVariable(Environment.GithubTokenVariable));
+    string token = null;
+    // if "GithubTokenVariable" is not set, fallback to the gh-cli defaults of GH_TOKEN, GITHUB_TOKEN
+    var variableNames = new[]{ Environment.GithubTokenVariable, "GH_TOKEN", "GITHUB_TOKEN" };
+    foreach (var name in variableNames)
+    {
+        token = context.EnvironmentVariable(name);
+        if(!string.IsNullOrEmpty(token))
+        {
+            break;
+        }
+    }
+    return new GitHubCredentials(token);
 }
 
 public static EmailCredentials GetEmailCredentials(ICakeContext context)

--- a/Cake.Recipe/Content/environment.cake
+++ b/Cake.Recipe/Content/environment.cake
@@ -47,7 +47,7 @@ public static class Environment
         string wyamDeployRemoteVariable = null,
         string wyamDeployBranchVariable = null)
     {
-        GithubTokenVariable = githubTokenVariable ?? "GITHUB_TOKEN";
+        GithubTokenVariable = githubTokenVariable ?? "GITHUB_PAT";
         GitterTokenVariable = gitterTokenVariable ?? "GITTER_TOKEN";
         GitterRoomIdVariable = gitterRoomIdVariable ?? "GITTER_ROOM_ID";
         SlackTokenVariable = slackTokenVariable ?? "SLACK_TOKEN";

--- a/docs/input/docs/fundamentals/environment-variables.md
+++ b/docs/input/docs/fundamentals/environment-variables.md
@@ -32,9 +32,15 @@ A token will be checked for first, and if not provided, the username and passwor
 In addition to these environment variables being present, and correct, the control variable [shouldPublishToGitHub](./set-parameters#shouldPublishToGitHub) also needs to be set to true.
 :::
 
-### GITHUB_TOKEN
+### GITHUB_PAT
 
 The Personal Access Token of the GitHub account to be used.
+
+:::{.alert .alert-info}
+**NOTE:**
+
+If `GITHUB_PAT` is not set, the alternatives of `GH_TOKEN` and `GITHUB_TOKEN` are considered.
+:::
 
 ## Gitter
 

--- a/docs/input/docs/fundamentals/set-variable-names.md
+++ b/docs/input/docs/fundamentals/set-variable-names.md
@@ -37,7 +37,7 @@ The `SetVariableNames` method uses the concept of optional parameters, in fact, 
 
 ### githubTokenVariable
 
-Default value: `GITHUB_TOKEN`
+Default value: `GITHUB_PAT`
 
 ### gitterTokenVariable
 

--- a/docs/input/docs/upgrading/1.x-to-2.x.md
+++ b/docs/input/docs/upgrading/1.x-to-2.x.md
@@ -12,7 +12,7 @@ Have a look at this [pull request](https://github.com/cake-contrib/Cake.DotNetVe
 
 ### Stop using username and password combination for accessing GitHub
 
-As of November 2020, GitHub is no longer going to support using a combination of username/password for accessing its API.  Instead, you _have to_ use a Personal Access Token.  As a result, the ability to provide a username/password via environment variables into Cake.Recipe has been removed.  Going forward, you will have to provide an environment variable for the [GITHUB_TOKEN](../fundamentals/environment-variables#github_token).
+As of November 2020, GitHub is no longer going to support using a combination of username/password for accessing its API.  Instead, you _have to_ use a Personal Access Token.  As a result, the ability to provide a username/password via environment variables into Cake.Recipe has been removed.  Going forward, you will have to provide an environment variable for the [GITHUB_PAT](../fundamentals/environment-variables#github_pat).
 
 ### Remove input parameters which are no longer required
 

--- a/docs/input/docs/usage/create-pre-release.md
+++ b/docs/input/docs/usage/create-pre-release.md
@@ -18,7 +18,7 @@ which are documented [here](creating-release){.alert-link}.
 2. Make sure that a GitHub milestone exists for this release.
 3. Make sure there were issues for all changes with the appropriate labels and the correct milestone set.
 4. Make sure that you have the following environment variables set in your local development environment:
-   - [GITHUB_TOKEN](../fundamentals/environment-variables#github_token)
+   - [GITHUB_PAT](../fundamentals/environment-variables#github_pat)
 5. Create a GitHub release draft by running:
    - On Windows: `.\build.ps1 --target=releasenotes --create-pre-release`
    - On MacOS/Linux: `./build.sh --target=releasenotes --create-pre-release`

--- a/docs/input/docs/usage/creating-release.md
+++ b/docs/input/docs/usage/creating-release.md
@@ -15,7 +15,7 @@ Both are not requirements though and you can adopt the steps to other environmen
 2. Make sure that a GitHub milestone exists for this release.
 3. Make sure there were issues for all changes with the appropriate labels and the correct milestone set.
 4. Make sure that you have the following environment variables set in your local development environment:
-   - [GITHUB_TOKEN](../fundamentals/environment-variables#github_token)
+   - [GITHUB_PAT](../fundamentals/environment-variables#github_pat)
 5. Create a GitHub release draft by running:
    - On Windows: `.\build.ps1 --target=releasenotes`
    - On MacOS/Linux: `./build.sh --target=releasenotes`


### PR DESCRIPTION
to ensure no conflicts between gh-cli and Cake.Recipe.
Also, when evaluating the GITHUB_PAT the following
environment-variables are considered (only if GITHUB_PAT is empty):
* GH_TOKEN
* GITHUB_TOKEN

This ensures backwards compatibility with previous versions of Cake.Recipe
and also conforms a bit more to gh-cli, as the two are used there, too.

fixes #700 