### PR TITLE
(GH-775) Add ability to skip duplicate package version during push

### DIFF
--- a/Cake.Recipe/Content/packages.cake
+++ b/Cake.Recipe/Content/packages.cake
@@ -261,7 +261,8 @@ public void PushNuGetPackages(ICakeContext context, bool isRelease, List<Package
 
             var nugetPushSettings = new NuGetPushSettings
                 {
-                    Source = nugetSource.PushUrl
+                    Source = nugetSource.PushUrl,
+                    SkipDuplicate = ToolSettings.SkipDuplicatePackages
                 };
 
             var canPushToNuGetSource = false;

--- a/Cake.Recipe/Content/toolsettings.cake
+++ b/Cake.Recipe/Content/toolsettings.cake
@@ -16,6 +16,7 @@ public static class ToolSettings
     public static MSBuildToolVersion BuildMSBuildToolVersion { get; private set; }
     public static int MaxCpuCount { get; private set; }
     public static string TargetFrameworkPathOverride { get; private set; }
+    public static bool SkipDuplicatePackages { get; private set; }
 
     public static string CodecovTool { get; private set; }
     public static string CoverallsTool { get; private set; }
@@ -99,7 +100,8 @@ public static class ToolSettings
         DirectoryPath targetFrameworkPathOverride = null,
         string[] dupFinderExcludeFilesByStartingCommentSubstring = null,
         int? dupFinderDiscardCost = null,
-        bool? dupFinderThrowExceptionOnFindingDuplicates = null
+        bool? dupFinderThrowExceptionOnFindingDuplicates = null,
+        bool skipDuplicatePackages = false
     )
     {
         context.Information("Setting up tools...");

--- a/docs/input/docs/fundamentals/set-tool-settings.md
+++ b/docs/input/docs/fundamentals/set-tool-settings.md
@@ -161,3 +161,11 @@ This is used when executing the DupFinder command line tool.  If set to true, an
 Type: `bool?`
 
 Default Value: `null`
+
+### skipDuplicatesPackages
+
+This is used to tell NuGet to ignore issues with trying to push package versions when the version already exist upstream, instead of failing the build.
+
+Type: `bool`
+
+Default Value: `false`


### PR DESCRIPTION
This allows duplicate NuGet packages to not throw
any errors when there is a duplicate package version
in the upstream repository, and instead allow the
build to continue without any failures

closes #775