### PR TITLE
(GH-793) error when vcsroot.branch is missing

### DIFF
--- a/Cake.Recipe/Content/teamcity.cake
+++ b/Cake.Recipe/Content/teamcity.cake
@@ -41,7 +41,13 @@ public class TeamCityRepositoryInfo : IRepositoryInfo
 {
     public TeamCityRepositoryInfo(ITeamCityProvider teamCity, ICakeContext context)
     {
-        Branch = context.Environment.GetEnvironmentVariable("vcsroot.branch").Replace("refs/heads/", string.Empty);
+        var branchName = context.Environment.GetEnvironmentVariable("vcsroot.branch");
+        if(string.IsNullOrEmpty(branchName)) 
+        {
+            throw new Exception(@"Environment variable ""vcsroot.branch"" could not be found. Cake.Recipe needs ""vcsroot.branch"" exposed as a build parameter.");
+        }
+
+        Branch = branchName.Replace("refs/heads/", string.Empty);
         Name = teamCity.Environment.Build.BuildConfName;
         Tag = new TeamCityTagInfo(context);
     }


### PR DESCRIPTION
replaces the current System.NullReferenceException
with something a bit more meaningful.

The error now looks like this:
![image](https://user-images.githubusercontent.com/349188/108910058-a0e28780-7625-11eb-8be3-c8d48e50895f.png)


fixes #793 