### PR TITLE
(GH-801) Update to push Chocolatey packages on Windows platforms

### DIFF
--- a/Cake.Recipe/Content/packages.cake
+++ b/Cake.Recipe/Content/packages.cake
@@ -137,19 +137,23 @@ BuildParameters.Tasks.CreateNuGetPackagesTask = Task("Create-NuGet-Packages")
 BuildParameters.Tasks.PublishPreReleasePackagesTask = Task("Publish-PreRelease-Packages")
     .WithCriteria(() => !BuildParameters.IsLocalBuild || BuildParameters.ForceContinuousIntegration, "Skipping because this is a local build, and force isn't being applied")
     .WithCriteria(() => !BuildParameters.IsTagged, "Skipping because current commit is tagged")
-    .WithCriteria(() => BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem, "Not running on preferred build agent operating system")
     .WithCriteria(() => BuildParameters.PreferredBuildProviderType == BuildParameters.BuildProvider.Type, "Not running on preferred build provider type")
     .IsDependentOn("Package")
     .Does(() =>
 {
-    var chocolateySources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.Chocolatey && p.IsRelease == false).ToList();
-    var nugetSources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.NuGet && p.IsRelease == false).ToList();
+    if (BuildParameters.PreferredBuildAgentOperatingSystem == PlatformFamily.Windows)
+    {
+        var chocolateySources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.Chocolatey && p.IsRelease == false).ToList();
+        PushChocolateyPackages(Context, false, chocolateySources);
+    }
 
-    PushChocolateyPackages(Context, false, chocolateySources);
-
-    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
-        PushNuGetPackages(Context, false, nugetSources);
-    });
+    if (BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem)
+    {
+        var nugetSources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.NuGet && p.IsRelease == false).ToList();
+        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+            PushNuGetPackages(Context, false, nugetSources);
+        });
+    }
 })
 .OnError(exception =>
 {
@@ -161,21 +165,25 @@ BuildParameters.Tasks.PublishPreReleasePackagesTask = Task("Publish-PreRelease-P
 BuildParameters.Tasks.PublishReleasePackagesTask = Task("Publish-Release-Packages")
     .WithCriteria(() => !BuildParameters.IsLocalBuild || BuildParameters.ForceContinuousIntegration, "Skipping because this is a local build, and force isn't being applied")
     .WithCriteria(() => BuildParameters.IsTagged, "Skipping because current commit is not tagged")
-    .WithCriteria(() => BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem, "Not running on preferred build agent operating system")
     .WithCriteria(() => BuildParameters.PreferredBuildProviderType == BuildParameters.BuildProvider.Type, "Not running on preferred build provider type")
     .IsDependentOn("Package")
     .Does(() =>
 {
-    var chocolateySources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.Chocolatey && p.IsRelease == true).ToList();
-    var nugetSources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.NuGet && p.IsRelease == true).ToList();
+    if (BuildParameters.PreferredBuildAgentOperatingSystem == PlatformFamily.Windows)
+    {
+        var chocolateySources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.Chocolatey && p.IsRelease == true).ToList();
+        PushChocolateyPackages(Context, true, chocolateySources);
+    }
 
-    PushChocolateyPackages(Context, true, chocolateySources);
-
-    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
-        PushNuGetPackages(Context, true, nugetSources);
-    });
-
-    BuildParameters.PublishReleasePackagesWasSuccessful = true;
+    if (BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem)
+    {
+        var nugetSources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.NuGet && p.IsRelease == true).ToList();
+        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+            PushNuGetPackages(Context, true, nugetSources);
+        });
+        // Only consider pushes to nuget and on the same Build Agent Operating System
+        BuildParameters.PublishReleasePackagesWasSuccessful = true;
+    }
 })
 .OnError(exception =>
 {
@@ -187,7 +195,7 @@ BuildParameters.Tasks.PublishReleasePackagesTask = Task("Publish-Release-Package
 
 public void PushChocolateyPackages(ICakeContext context, bool isRelease, List<PackageSourceData> chocolateySources)
 {
-    if (BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows && DirectoryExists(BuildParameters.Paths.Directories.ChocolateyPackages))
+    if (DirectoryExists(BuildParameters.Paths.Directories.ChocolateyPackages))
     {
         Information("Number of configured {0} Chocolatey Sources: {1}", isRelease ? "Release" : "PreRelease", chocolateySources.Count());
 
@@ -245,7 +253,7 @@ public void PushChocolateyPackages(ICakeContext context, bool isRelease, List<Pa
     }
     else
     {
-        context.Information("Unable to publish Chocolatey packages. IsRunningOnWindows: {0} Chocolatey Packages Directory Exists: {1}", BuildParameters.BuildAgentOperatingSystem, DirectoryExists(BuildParameters.Paths.Directories.ChocolateyPackages));
+        context.Information("Unable to publish Chocolatey packages. Chocolatey Packages Directory Exists: {0}", DirectoryExists(BuildParameters.Paths.Directories.ChocolateyPackages));
     }
 }
 


### PR DESCRIPTION
The current logic of pushing chocolatey packages uses the current preferred build platform to decide when to push the package.
Unfortunately, at a later part this is further restricted to only push those packages on Windows platforms.

This eventually causes an issue where the packages are never pushed if the preferred build platform os is set to something other than ﻿Windows.
This pull request fixes that issues by always trying to push chocolatey when the current OS is Windows, even if the preferred build platform os is set to something else.

fixes #801
