### PR TITLE
Update Cake.Figlet reference from 2.0.0 to 2.0.1

### DIFF
--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -11,7 +11,7 @@
 #addin nuget:?package=MimeTypesMap&version=1.0.8
 #addin nuget:?package=Cake.Email.Common&version=0.4.2
 #addin nuget:?package=Cake.Email&version=1.0.0
-#addin nuget:?package=Cake.Figlet&version=2.0.0
+#addin nuget:?package=Cake.Figlet&version=2.0.1
 #addin nuget:?package=Cake.Gitter&version=1.0.1
 #addin nuget:?package=Cake.Incubator&version=6.0.0
 #addin nuget:?package=Cake.Kudu&version=1.0.0


### PR DESCRIPTION
This pull request was manually created because Cake.AddinDiscoverer triggered AbuseException before it was able to submit this PR.

Resolves #823