### PR TITLE
Update Cake.Transifex reference from 1.0.0 to 1.0.1

### DIFF
--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -17,7 +17,7 @@
 #addin nuget:?package=Cake.Kudu&version=1.0.0
 #addin nuget:?package=Cake.MicrosoftTeams&version=1.0.0
 #addin nuget:?package=Cake.Slack&version=1.0.0
-#addin nuget:?package=Cake.Transifex&version=1.0.0
+#addin nuget:?package=Cake.Transifex&version=1.0.1
 #addin nuget:?package=Cake.Twitter&version=1.0.0
 #addin nuget:?package=Cake.Wyam&version=2.2.10
 


### PR DESCRIPTION
This pull request was manually created because Cake.AddinDiscoverer triggered AbuseException before it was able to submit this PR.

Resolves #826