### PR TITLE
Update Cake.Coveralls reference from 1.0.0 to 1.0.1

### DIFF
--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -3,7 +3,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #addin nuget:?package=Cake.Codecov&version=1.0.0
-#addin nuget:?package=Cake.Coveralls&version=1.0.0
+#addin nuget:?package=Cake.Coveralls&version=1.0.1
 #addin nuget:?package=Cake.Coverlet&version=2.5.4
 #addin nuget:?package=Portable.BouncyCastle&version=1.8.5
 #addin nuget:?package=MimeKit&version=2.9.1


### PR DESCRIPTION
This pull request was manually created because Cake.AddinDiscoverer triggered AbuseException before it was able to submit this PR.

Resolves #827