### PR TITLE
Update Cake.Gitter reference from 1.0.1 to 1.0.2

### DIFF
--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -12,7 +12,7 @@
 #addin nuget:?package=Cake.Email.Common&version=0.4.2
 #addin nuget:?package=Cake.Email&version=1.0.0
 #addin nuget:?package=Cake.Figlet&version=2.0.0
-#addin nuget:?package=Cake.Gitter&version=1.0.1
+#addin nuget:?package=Cake.Gitter&version=1.0.2
 #addin nuget:?package=Cake.Incubator&version=6.0.0
 #addin nuget:?package=Cake.Kudu&version=1.0.0
 #addin nuget:?package=Cake.MicrosoftTeams&version=1.0.0


### PR DESCRIPTION
This pull request was manually created because Cake.AddinDiscoverer triggered AbuseException before it was able to submit this PR.

Resolves #828