### PR TITLE
(#847) Bump CakeContrib.Guidelines to v1.1.1 to update NuGet package icon

### DIFF
--- a/Source/Cake.Recipe/Cake.Recipe.csproj
+++ b/Source/Cake.Recipe/Cake.Recipe.csproj
@@ -30,7 +30,7 @@ NOTE:  Currently, Cake.Recipe itself is built using 0.38.4, and as a result, the
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CakeContrib.Guidelines" Version="1.0.0">
+    <PackageReference Include="CakeContrib.Guidelines" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Closes #847
