### PR TITLE
(#845) specified the full versions of GitHub actions

### DIFF
--- a/docs/input/docs/ci-systems/github.md
+++ b/docs/input/docs/ci-systems/github.md
@@ -31,9 +31,14 @@ Description: Building with GitHub Actions
 :::{.alert .alert-info}
 **NOTE:**
 
-The following example shows pinned virtual environments.
+The following example shows pinned virtual environments (e.g. `ubuntu-18.04` instead of `ubuntu-latest`) and actions with full versions given (e.g. `actions/checkout@v2.3.4` instead of `actions/checkout@v2`).
+
 The current list of available environments for GitHub actions can be found in 
 [the documentation](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).
+
+The current versions for each action have to be looked up individually.
+We advise you to setup [dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically)
+or [renovate](https://www.whitesourcesoftware.com/free-developer-tools/renovate) or similar to automate the process of updating those versions.
 
 :::
 
@@ -62,13 +67,13 @@ jobs:
 
     steps:
       - name: Checkout the repository 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       
       - name: Fetch all tags and branches
         run: git fetch --prune --unshallow
 
       - name: Cache Tools
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.6
         with:
           path: tools
           key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
@@ -83,14 +88,14 @@ jobs:
           cake-bootstrap: true
 
       - name: Upload Issues-Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         with:
           if-no-files-found: warn
           name: ${{ matrix.os }} issues
           path: BuildArtifacts/report.html
 
       - name: Upload Packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         if: runner.os == 'Windows'
         with:
           if-no-files-found: warn


### PR DESCRIPTION
in the documentation for GitHub. Also added hints to dependabot and
renovate.

fixes #845 