### PR TITLE
(#854) modified resolution of RequireToolNotRegistered

### DIFF
--- a/Source/Cake.Recipe/Content/build.cake
+++ b/Source/Cake.Recipe/Content/build.cake
@@ -136,7 +136,7 @@ BuildParameters.Tasks.RestoreTask = Task("Restore")
     .Does(() =>
 {
     Information("Restoring {0}...", BuildParameters.SolutionFilePath);
-    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget.exe" }, () => {
         NuGetRestore(
             BuildParameters.SolutionFilePath,
             new NuGetRestoreSettings

--- a/Source/Cake.Recipe/Content/packages.cake
+++ b/Source/Cake.Recipe/Content/packages.cake
@@ -70,7 +70,7 @@ BuildParameters.Tasks.CreateNuGetPackageTask = Task("Create-Nuget-Package")
     if (BuildParameters.NuSpecFilePath != null) {
         EnsureDirectoryExists(BuildParameters.Paths.Directories.NuGetPackages);
 
-        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget.exe" }, () => {
             // Create packages.
             NuGetPack(BuildParameters.NuSpecFilePath, new NuGetPackSettings {
                 Version = buildVersion.SemVersion,
@@ -112,7 +112,7 @@ BuildParameters.Tasks.CreateNuGetPackagesTask = Task("Create-NuGet-Packages")
         settings.ArgumentCustomization = args => args.AppendSwitch("-SymbolPackageFormat", "snupkg");
     }
 
-    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => { });
+    RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget.exe" }, () => { });
 
     foreach (var nuspecFile in nuspecFiles)
     {
@@ -151,7 +151,7 @@ BuildParameters.Tasks.PublishPreReleasePackagesTask = Task("Publish-PreRelease-P
     if (BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem)
     {
         var nugetSources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.NuGet && p.IsRelease == false).ToList();
-        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget.exe" }, () => {
             PushNuGetPackages(Context, false, nugetSources);
         });
     }
@@ -180,7 +180,7 @@ BuildParameters.Tasks.PublishReleasePackagesTask = Task("Publish-Release-Package
     if (BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem)
     {
         var nugetSources = BuildParameters.PackageSources.Where(p => p.Type == FeedType.NuGet && p.IsRelease == true).ToList();
-        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget", "nuget.exe" }, () => {
+        RequireToolNotRegistered(ToolSettings.NuGetTool, new[] { "nuget.exe" }, () => {
             PushNuGetPackages(Context, true, nugetSources);
         });
         // Only consider pushes to nuget and on the same Build Agent Operating System

--- a/Source/Cake.Recipe/Content/tools.cake
+++ b/Source/Cake.Recipe/Content/tools.cake
@@ -3,20 +3,24 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 Action<string, string[], Action> RequireToolNotRegistered = (tool, toolNames, action) => {
+    var toolsFolder = Context.FileSystem.GetDirectory(
+        Context.Configuration.GetToolPath(Context.Environment.WorkingDirectory, Context.Environment));
     bool found = false;
 
+    Context.Verbose("Searching for tool {0} in tools: {1}", string.Join("|", toolNames), toolsFolder.Path);
     foreach (var name in toolNames)
     {
         if (found)
         {
             break;
         }
-        var path = Context.Tools.Resolve(name);
+        var path = Context.GetFiles(toolsFolder.Path + $"/**/{name}").FirstOrDefault();
         found = path != null;
     }
 
     if (!found)
     {
+        Context.Verbose("Tool not found. Requiring '{0}'", tool);
         RequireTool(tool, action);
     }
     else


### PR DESCRIPTION
so that only tools from the tools folder are being used
and not some random tool installed on the system.

Also modified resolution of nuget so that only `nuget.exe` is searched and never `nuget`.
The reasoning being, that the required tool (NuGet.Commandline)
will never install a tool `nuget` but always only install `nuget.exe`.

fixes #854 