### PR TITLE
(#862) bumped JetBrains.ReSharper.CommandLineTools

### DIFF
--- a/Source/Cake.Recipe/Content/analyzing.cake
+++ b/Source/Cake.Recipe/Content/analyzing.cake
@@ -9,7 +9,8 @@ BuildParameters.Tasks.InspectCodeTask = Task("InspectCode")
 
         var settings = new InspectCodeSettings() {
             SolutionWideAnalysis = true,
-            OutputFile = inspectCodeLogFilePath
+            OutputFile = inspectCodeLogFilePath,
+            ArgumentCustomization = x => x.Append("--no-build")
         };
 
         if (FileExists(BuildParameters.SourceDirectoryPath.CombineWithFilePath(BuildParameters.ResharperSettingsFileName)))

--- a/Source/Cake.Recipe/Content/toolsettings.cake
+++ b/Source/Cake.Recipe/Content/toolsettings.cake
@@ -43,7 +43,7 @@ public static class ToolSettings
         string gitReleaseManagerTool = "#tool nuget:?package=GitReleaseManager&version=0.11.0",
         // This is specifically pinned to 5.0.1 as later versions break compatibility with Unix.
         string gitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=5.0.1",
-        string reSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2020.3.4",
+        string reSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2021.2.1",
         string kuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.5.3",
         string wyamTool = "#tool nuget:?package=Wyam&version=2.2.9",
         string xunitTool = "#tool nuget:?package=xunit.runner.console&version=2.4.1",


### PR DESCRIPTION
to 2021.2.1, to support ToolsVersion 17 (VS 2022)

I've had [the workaround](https://github.com/cake-contrib/Cake.Recipe/issues/862#issuecomment-908270457) in place in some builds for a while now, without any problems. I see no harm in bumping JetBrains.ReSharper.CommandLineTools

fixes #862 