### PR TITLE
(#762) Update Cake and Cake.Issues.Recipe

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.1.0",
+      "version": "1.3.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -21,7 +21,7 @@
 #addin nuget:?package=Cake.Twitter&version=1.0.0
 #addin nuget:?package=Cake.Wyam&version=2.2.12
 
-#load nuget:?package=Cake.Issues.Recipe&version=0.4.3
+#load nuget:?package=Cake.Issues.Recipe&version=1.3.2
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));

--- a/Source/Cake.Recipe/Content/analyzing.cake
+++ b/Source/Cake.Recipe/Content/analyzing.cake
@@ -21,7 +21,7 @@ BuildParameters.Tasks.InspectCodeTask = Task("InspectCode")
         InspectCode(BuildParameters.SolutionFilePath, settings);
 
         // Pass path to InspectCode log file to Cake.Issues.Recipe
-        IssuesParameters.InputFiles.InspectCodeLogFilePath = inspectCodeLogFilePath;
+        IssuesParameters.InputFiles.AddInspectCodeLogFile(inspectCodeLogFilePath);
     })
 );
 

--- a/Source/Cake.Recipe/Content/build.cake
+++ b/Source/Cake.Recipe/Content/build.cake
@@ -198,7 +198,7 @@ BuildParameters.Tasks.BuildTask = Task("Build")
             MSBuild(BuildParameters.SolutionFilePath, msbuildSettings);
 
             // Pass path to MsBuild log file to Cake.Issues.Recipe
-            IssuesParameters.InputFiles.MsBuildBinaryLogFilePath = BuildParameters.Paths.Files.BuildBinLogFilePath;
+            IssuesParameters.InputFiles.AddMsBuildBinaryLogFile(BuildParameters.Paths.Files.BuildBinLogFilePath);
         }
         else
         {
@@ -240,7 +240,7 @@ BuildParameters.Tasks.DotNetCoreBuildTask = Task("DotNetCore-Build")
         });
 
         // We set this here, so we won't have a failure in case this task is never called
-        IssuesParameters.InputFiles.MsBuildBinaryLogFilePath = BuildParameters.Paths.Files.BuildBinLogFilePath;
+        IssuesParameters.InputFiles.AddMsBuildBinaryLogFile(BuildParameters.Paths.Files.BuildBinLogFilePath);
 
         CopyBuildOutput(buildVersion);
     });


### PR DESCRIPTION
This will allow us to push out a 3.0.0 which will support Cake 1.x, and
then we can look to support Cake 2.x.

Relates to #762 