### PR TITLE
(#877) Remove usage of Cake.Figlet

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.3.0",
+      "version": "2.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -11,7 +11,6 @@
 #addin nuget:?package=MimeTypesMap&version=1.0.8
 #addin nuget:?package=Cake.Email.Common&version=0.4.2
 #addin nuget:?package=Cake.Email&version=1.0.2
-#addin nuget:?package=Cake.Figlet&version=2.0.1
 #addin nuget:?package=Cake.Gitter&version=1.1.0
 #addin nuget:?package=Cake.Incubator&version=6.0.0
 #addin nuget:?package=Cake.Kudu&version=1.0.1

--- a/Source/Cake.Recipe/Content/buildProvider.cake
+++ b/Source/Cake.Recipe/Content/buildProvider.cake
@@ -72,7 +72,7 @@ public enum BuildProviderType
 
 public static IBuildProvider GetBuildProvider(ICakeContext context, BuildSystem buildSystem)
 {
-    if (buildSystem.IsRunningOnAzurePipelines || buildSystem.IsRunningOnAzurePipelinesHosted)
+    if (buildSystem.IsRunningOnAzurePipelines)
     {
         context.Information("Using Azure DevOps Pipelines Provider...");
         return new AzurePipelinesBuildProvider(buildSystem.AzurePipelines, context.Environment, context);

--- a/Source/Cake.Recipe/Content/setup.cake
+++ b/Source/Cake.Recipe/Content/setup.cake
@@ -1,3 +1,5 @@
+using Spectre.Console;
+
 #if !CUSTOM_VERSIONING
 Setup<BuildVersion>(context =>
 {
@@ -36,7 +38,7 @@ Setup<BuildVersion>(context =>
 
 Setup<BuildData>(context =>
 {
-    Information(Figlet(BuildParameters.Title));
+    AnsiConsole.Write(new FigletText(BuildParameters.Title));
 
     Information("Starting Setup...");
 


### PR DESCRIPTION
Use the built in aliases that are part of Spectre.Console.

Fixes #877 