### PR TITLE
(#723) Use alias for getting Arguments

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,5 +33,5 @@ jobs:
         with:
           script-path: recipe.cake
           target: CI
-          cake-version: 1.1.0
+          cake-version: 1.3.0
           cake-bootstrap: true

--- a/Source/Cake.Recipe/Content/configuration.cake
+++ b/Source/Cake.Recipe/Content/configuration.cake
@@ -2,12 +2,8 @@ public static Cake.Core.Configuration.ICakeConfiguration GetConfiguration(this I
 {
     var configProvider = new Cake.Core.Configuration.CakeConfigurationProvider(context.FileSystem, context.Environment);
     
-    // This is very much a hack until this issue is implemented:
-    // https://github.com/cake-build/cake/issues/2690
-    var arguments = (Dictionary<string, List<string>>)context.Arguments.GetType().GetField("_arguments", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(context.Arguments);
-
     return configProvider.CreateConfiguration(
         context.Environment.WorkingDirectory,
-        arguments.ToDictionary(x => x.Key, y=>y.Value.LastOrDefault())
+        context.Arguments().ToDictionary(x => x.Key, y=>y.Value.LastOrDefault())
         );
 }


### PR DESCRIPTION
Rather than use the hack that was being used, make use of the Arguments
alias which has now been created.

Fixes #723 