### PR TITLE
(GH-911) Update Cake.Twitter reference from 1.0.0 to 2.0.0

### DIFF
--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -17,7 +17,7 @@
 #addin nuget:?package=Cake.MicrosoftTeams&version=1.0.1
 #addin nuget:?package=Cake.Slack&version=1.0.1
 #addin nuget:?package=Cake.Transifex&version=1.0.1
-#addin nuget:?package=Cake.Twitter&version=1.0.0
+#addin nuget:?package=Cake.Twitter&version=2.0.0
 #addin nuget:?package=Cake.Wyam&version=2.2.12
 
 #load nuget:?package=Cake.Issues.Recipe&version=1.3.2


### PR DESCRIPTION
For some unknown reason Addin Discoverer failed to submit this PR when it ran last night. I'm guessing it triggered github's abuse detection.

Therefore I am manually submitting this PR.

Resolves #911 