### PR TITLE
(#897) Added a configuration for the MessageParameters

### DIFF
--- a/Source/Cake.Recipe/Content/build.cake
+++ b/Source/Cake.Recipe/Content/build.cake
@@ -34,26 +34,27 @@ Teardown<BuildVersion>((context, buildVersion) =>
             BuildParameters.IsTagged &&
             !BuildParameters.IsRunningIntegrationTests)
         {
+            var messageArguments = BuildParameters.MessageArguments(buildVersion);
             if (BuildParameters.CanPostToTwitter && BuildParameters.ShouldPostToTwitter)
             {
-                SendMessageToTwitter(string.Format(BuildParameters.TwitterMessage, buildVersion.Version, BuildParameters.Title));
+                SendMessageToTwitter(string.Format(BuildParameters.TwitterMessage, messageArguments));
             }
 
             if (BuildParameters.CanPostToGitter && BuildParameters.ShouldPostToGitter)
             {
-                SendMessageToGitterRoom(string.Format(BuildParameters.GitterMessage, buildVersion.Version, BuildParameters.Title));
+                SendMessageToGitterRoom(string.Format(BuildParameters.GitterMessage, messageArguments));
             }
 
             if (BuildParameters.CanPostToMicrosoftTeams && BuildParameters.ShouldPostToMicrosoftTeams)
             {
-                SendMessageToMicrosoftTeams(string.Format(BuildParameters.MicrosoftTeamsMessage, buildVersion.Version, BuildParameters.Title));
+                SendMessageToMicrosoftTeams(string.Format(BuildParameters.MicrosoftTeamsMessage, messageArguments));
             }
 
             if (BuildParameters.CanSendEmail && BuildParameters.ShouldSendEmail && !string.IsNullOrEmpty(BuildParameters.EmailRecipient))
             {
                 var subject = $"Continuous Integration Build of {BuildParameters.Title} completed successfully";
                 var message = new StringBuilder();
-                message.AppendLine(string.Format(BuildParameters.StandardMessage, buildVersion.Version, BuildParameters.Title) + "<br/>");
+                message.AppendLine(string.Format(BuildParameters.StandardMessage, messageArguments) + "<br/>");
                 message.AppendLine("<br/>");
                 message.AppendLine($"<strong>Name</strong>: {BuildParameters.Title}<br/>");
                 message.AppendLine($"<strong>Version</strong>: {buildVersion.SemVersion}<br/>");

--- a/Source/Cake.Recipe/Content/parameters.cake
+++ b/Source/Cake.Recipe/Content/parameters.cake
@@ -157,6 +157,7 @@ public static class BuildParameters
     public static DirectoryPath RestorePackagesDirectory { get; private set; }
 
     public static IBuildProvider BuildProvider { get; private set; }
+    public static Func<BuildVersion, object[]> MessageArguments { get; private set; }
 
     static BuildParameters()
     {
@@ -404,7 +405,8 @@ public static class BuildParameters
         DirectoryPath restorePackagesDirectory = null,
         List<PackageSourceData> packageSourceDatas = null,
         PlatformFamily preferredBuildAgentOperatingSystem = PlatformFamily.Windows,
-        BuildProviderType preferredBuildProviderType = BuildProviderType.AppVeyor
+        BuildProviderType preferredBuildProviderType = BuildProviderType.AppVeyor,
+        Func<BuildVersion, object[]> messageArguments = null
         )
     {
         if (context == null)
@@ -522,6 +524,7 @@ public static class BuildParameters
         IsPullRequest = BuildProvider.PullRequest.IsPullRequest;
         IsMainRepository = StringComparer.OrdinalIgnoreCase.Equals(string.Concat(repositoryOwner, "/", RepositoryName), BuildProvider.Repository.Name);
         IsPublicRepository = isPublicRepository;
+        MessageArguments = messageArguments ?? ((x) => new object[]{ x.Version, BuildParameters.Title });
 
         IsTagged = (
             BuildProvider.Repository.Tag.IsTag &&


### PR DESCRIPTION
So now, when StandardMessage, TwitterMessage, GitterMessage,
or MicrosoftTeamsMessage are changed, the parameters
which are sent to string.Format can also be changed by
settings MessageParameters.

The default for MessageParameters is equal to the "old" value,
so this change is compatible with "old" settings where the
messages were either changed or unchanged.

fixes #897 