### PR TITLE
(#979) Add support for new transifex client

### DIFF
--- a/Source/Cake.Recipe/Content/parameters.cake
+++ b/Source/Cake.Recipe/Content/parameters.cake
@@ -359,7 +359,7 @@ public static class BuildParameters
         AppVeyorAccountName = appVeyorAccountName ?? RepositoryOwner.Replace("-", "").ToLower();
         AppVeyorProjectSlug = appVeyorProjectSlug ?? RepositoryName.Replace(".", "-").ToLower();
 
-        TransifexEnabled = transifexEnabled ?? TransifexIsConfiguredForRepository(context);
+        TransifexEnabled = transifexEnabled ?? context.FileExists("./.tx/config");
         TransifexPullMode = transifexPullMode;
         TransifexPullPercentage = transifexPullPercentage;
 

--- a/Source/Cake.Recipe/Content/tasks.cake
+++ b/Source/Cake.Recipe/Content/tasks.cake
@@ -41,7 +41,6 @@ public class BuildTasks
     public CakeTaskBuilder TransifexPullTranslations { get; set; }
     public CakeTaskBuilder TransifexPushSourceResource { get; set; }
     public CakeTaskBuilder TransifexPushTranslations { get; set; }
-    public CakeTaskBuilder TransifexSetupTask { get; set; }
     public CakeTaskBuilder DotNetCoreTestTask { get; set; }
     public CakeTaskBuilder IntegrationTestTask { get;set; }
     public CakeTaskBuilder GenerateFriendlyTestReportTask { get; set; }


### PR DESCRIPTION
The old transifex-client that was previously supported has stopped working some time ago, the new executable that replaces it is not fully compatibly with how we set up the api token when connecting to transifex.

This new executable also adds support for new global arguments where the token can be specified with, and as such this PR updates cake.recipe to be compatible with this new executable.
The changes are made directly here in Cake.Recipe instead of in Cake.Transifex for the global argument, as it won't be backported to be supported on older versions of Cake.

fixes #979