### PR TITLE
By default, Cake.Recipe should not post to Gitter

### DIFF
--- a/Source/Cake.Recipe/Content/parameters.cake
+++ b/Source/Cake.Recipe/Content/parameters.cake
@@ -353,7 +353,7 @@ public static class BuildParameters
         string repositoryName = null,
         string appVeyorAccountName = null,
         string appVeyorProjectSlug = null,
-        bool shouldPostToGitter = true,
+        bool shouldPostToGitter = false,
         bool shouldPostToSlack = true,
         bool shouldPostToTwitter = true,
         bool shouldPostToMicrosoftTeams = false,


### PR DESCRIPTION
This is a non-breaking change that simply changes the default value of `shouldPostToGitter` to `false` to avoid the problem described in #995 