### PR TITLE
(#1001) Remove tokenless support for Codecov

### DIFF
--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -2,7 +2,7 @@
 // ADDINS
 ///////////////////////////////////////////////////////////////////////////////
 
-#addin nuget:?package=Cake.Codecov&version=1.0.1
+#addin nuget:?package=Cake.Codecov&version=2.0.0
 #addin nuget:?package=Cake.Coveralls&version=1.1.0
 #addin nuget:?package=Cake.Coverlet&version=2.5.4
 #addin nuget:?package=Portable.BouncyCastle&version=1.8.5

--- a/Source/Cake.Recipe/Content/appveyor.cake
+++ b/Source/Cake.Recipe/Content/appveyor.cake
@@ -84,7 +84,8 @@ public class AppVeyorBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
-    public bool SupportsTokenlessCodecov { get; } = true;
+    [System.Obsolete("Codecov CLI no longer officially supports tokenless uploads.")]
+    public bool SupportsTokenlessCodecov { get; } = false;
 
     public BuildProviderType Type { get; } = BuildProviderType.AppVeyor;
 

--- a/Source/Cake.Recipe/Content/azurepipelines.cake
+++ b/Source/Cake.Recipe/Content/azurepipelines.cake
@@ -141,7 +141,8 @@ public class AzurePipelinesBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
-    public bool SupportsTokenlessCodecov { get; } = true;
+    [System.Obsolete("Codecov CLI no longer officially supports tokenless uploads.")]
+    public bool SupportsTokenlessCodecov { get; } = false;
 
     public BuildProviderType Type { get; } = BuildProviderType.AzurePipelines;
 

--- a/Source/Cake.Recipe/Content/buildProvider.cake
+++ b/Source/Cake.Recipe/Content/buildProvider.cake
@@ -51,6 +51,7 @@ public interface IBuildProvider
 
     IBuildInfo Build { get; }
 
+    [System.Obsolete("Codecov CLI no longer officially supports tokenless uploads.")]
     bool SupportsTokenlessCodecov { get; }
 
     IEnumerable<string> PrintVariables { get; }

--- a/Source/Cake.Recipe/Content/codecov.cake
+++ b/Source/Cake.Recipe/Content/codecov.cake
@@ -5,7 +5,7 @@
 BuildParameters.Tasks.UploadCodecovReportTask = Task("Upload-Codecov-Report")
     .WithCriteria(() => BuildParameters.IsMainRepository, "Skipping because not running from the main repository")
     .WithCriteria(() => BuildParameters.ShouldRunCodecov, "Skipping because uploading to codecov is disabled")
-    .WithCriteria(() => BuildParameters.CanPublishToCodecov, "Skipping because repo token is missing, or not running on appveyor")
+    .WithCriteria(() => BuildParameters.CanPublishToCodecov, "Skipping because repo token is missing, or not running on GitHub CI")
     .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.CodecovGlobalTool : ToolSettings.CodecovTool, () => {
         var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.xml");
         if (FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
@@ -17,7 +17,8 @@ BuildParameters.Tasks.UploadCodecovReportTask = Task("Upload-Codecov-Report")
         {
             var settings = new CodecovSettings {
                 Files = coverageFiles.Select(f => f.FullPath),
-                Required = true
+                NonZero = true,
+                Token = BuildParameters.Codecov.RepoToken
             };
             if (buildVersion != null &&
                 !string.IsNullOrEmpty(buildVersion.FullSemVersion) &&

--- a/Source/Cake.Recipe/Content/credentials.cake
+++ b/Source/Cake.Recipe/Content/credentials.cake
@@ -96,6 +96,11 @@ public class CodecovCredentials : CoverallsCredentials
 
 public class CoverallsCredentials
 {
+    public bool HasCredentials
+    {
+        get { return !string.IsNullOrEmpty(RepoToken); }
+    }
+
     public string RepoToken { get; private set; }
 
     public CoverallsCredentials(string repoToken)
@@ -187,8 +192,16 @@ public static AppVeyorCredentials GetAppVeyorCredentials(ICakeContext context)
 
 public static CodecovCredentials GetCodecovCredentials(ICakeContext context)
 {
-    return new CodecovCredentials(
-        context.EnvironmentVariable(Environment.CodecovRepoTokenVariable));
+    var token = context.EnvironmentVariable(Environment.CodecovRepoTokenVariable);
+
+    if (string.IsNullOrEmpty(token))
+    {
+        // Fallback to attempt to check for the conventional CODECOV_TOKEN which
+        // the CLI tools read automatically.
+        token = context.EnvironmentVariable("CODECOV_TOKEN");
+    }
+
+    return new CodecovCredentials(token);
 }
 
 public static CoverallsCredentials GetCoverallsCredentials(ICakeContext context)

--- a/Source/Cake.Recipe/Content/github-actions.cake
+++ b/Source/Cake.Recipe/Content/github-actions.cake
@@ -128,7 +128,8 @@ public class GitHubActionBuildProvider : IBuildProvider
     public IPullRequestInfo PullRequest { get; }
     public IRepositoryInfo Repository { get; }
 
-    public bool SupportsTokenlessCodecov { get; } = true;
+    [System.Obsolete("Codecov CLI no longer officially supports tokenless uploads.")]
+    public bool SupportsTokenlessCodecov { get; } = false;
 
     public BuildProviderType Type { get; } = BuildProviderType.GitHubActions;
 

--- a/Source/Cake.Recipe/Content/localbuild.cake
+++ b/Source/Cake.Recipe/Content/localbuild.cake
@@ -160,6 +160,7 @@ public class LocalBuildBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
+    [System.Obsolete("Codecov CLI no longer officially supports tokenless uploads.")]
     public bool SupportsTokenlessCodecov { get; } = false;
 
     public BuildProviderType Type { get; } = BuildProviderType.Local;

--- a/Source/Cake.Recipe/Content/parameters.cake
+++ b/Source/Cake.Recipe/Content/parameters.cake
@@ -213,10 +213,7 @@ public static class BuildParameters
     {
         get
         {
-            return ShouldRunCodecov && (
-                BuildProvider.SupportsTokenlessCodecov ||
-                !string.IsNullOrEmpty(Codecov.RepoToken)
-            );
+            return ShouldRunCodecov && Codecov.HasCredentials;
         }
     }
 
@@ -224,7 +221,7 @@ public static class BuildParameters
     {
         get
         {
-            return ShouldRunCoveralls && !string.IsNullOrEmpty(BuildParameters.Coveralls.RepoToken);
+            return ShouldRunCoveralls && Coveralls.HasCredentials;
         }
     }
 

--- a/Source/Cake.Recipe/Content/teamcity.cake
+++ b/Source/Cake.Recipe/Content/teamcity.cake
@@ -96,6 +96,7 @@ public class TeamCityBuildProvider : IBuildProvider
 
     public IBuildInfo Build { get; }
 
+    [System.Obsolete("Codecov CLI no longer officially supports tokenless uploads.")]
     public bool SupportsTokenlessCodecov { get; } = false;
 
     public BuildProviderType Type { get; } = BuildProviderType.TeamCity;

--- a/Source/Cake.Recipe/Content/toolsettings.cake
+++ b/Source/Cake.Recipe/Content/toolsettings.cake
@@ -28,6 +28,7 @@ public static class ToolSettings
     public static string ReportGeneratorTool { get; private set; }
     public static string ReportUnitTool { get; private set; }
 
+    [System.Obsolete("The Global Tool of Codecov is no longer supported. Use the Normal codecovTool going forward.")]
     public static string CodecovGlobalTool { get; private set; }
     public static string CoverallsGlobalTool { get; private set; }
     public static string GitReleaseManagerGlobalTool { get; private set; }
@@ -37,7 +38,7 @@ public static class ToolSettings
     public static string KuduSyncGlobalTool { get; private set; }
 
     public static void SetToolPreprocessorDirectives(
-        string codecovTool = "#tool nuget:?package=codecov&version=1.13.0",
+        string codecovTool = "#tool nuget:?package=CodecovUploader&version=0.7.3",
         // This is specifically pinned to 0.7.0 as later versions of same package publish .Net Global Tool, rather than full framework version
         string coverallsTool = "#tool nuget:?package=coveralls.net&version=0.7.0",
         string gitReleaseManagerTool = "#tool nuget:?package=GitReleaseManager&version=0.18.0",
@@ -52,7 +53,7 @@ public static class ToolSettings
         string openCoverTool = "#tool nuget:?package=OpenCover&version=4.7.1221",
         string reportGeneratorTool = "#tool nuget:?package=ReportGenerator&version=5.3.8",
         string reportUnitTool = "#tool nuget:?package=ReportUnit&version=1.2.1",
-        string codecovGlobalTool = "#tool dotnet:?package=Codecov.Tool&version=1.13.0",
+        string codecovGlobalTool = "#tool nuget:?package=CodecovUploader&version=0.7.3",
         string coverallsGlobalTool = "#tool dotnet:?package=coveralls.net&version=1.0.0",
         string gitReleaseManagerGlobalTool = "#tool dotnet:?package=GitReleaseManager.Tool&version=0.18.0",
         string gitVersionGlobalTool = "#tool dotnet:?package=GitVersion.Tool&version=5.12.0",

--- a/Source/Cake.Recipe/Content/travis-ci.cake
+++ b/Source/Cake.Recipe/Content/travis-ci.cake
@@ -60,7 +60,8 @@ public class TravisCiBuildProvider : IBuildProvider
     public IPullRequestInfo PullRequest { get; }
     public IRepositoryInfo Repository { get; }
 
-    public bool SupportsTokenlessCodecov { get; } = true;
+    [System.Obsolete("Codecov CLI no longer officially supports tokenless uploads.")]
+    public bool SupportsTokenlessCodecov { get; } = false;
 
     public BuildProviderType Type { get; } = BuildProviderType.Travis;
 

--- a/docs/input/docs/fundamentals/environment-variables.md
+++ b/docs/input/docs/fundamentals/environment-variables.md
@@ -155,13 +155,7 @@ In addition to this environment variable being present, and correct, the control
 
 ### CODECOV_REPO_TOKEN
 
-API token for uploading coverage reports to codecov.io.
-
-:::{.alert .alert-info}
-**NOTE:**
-
-This token is entirely optional for public repositories building on AppVeyor, and is recommended to only be used on private repositories*
-:::
+API token for uploading coverage reports to [Codecov](https://about.codecov.io/).
 
 ## Coveralls
 
@@ -175,7 +169,7 @@ In addition to this environment variable being present, and correct, the control
 
 ### COVERALLS_REPO_TOKEN
 
-API token for uploading coverage reports to codecov.io.
+API token for uploading coverage reports to [Coveralls](https://coveralls.io/).
 
 ## Transifex
 

--- a/docs/input/docs/upgrading/3.x-to-4.x.md
+++ b/docs/input/docs/upgrading/3.x-to-4.x.md
@@ -15,3 +15,12 @@ Cake.Recipe is now using 2.3.0 of Cake, and as such, we recommend that any build
 In this release of Cake.Recipe we have upgraded to 2.0.0 of Cake.Issues.Recipe. If in your build scripts you have extended the built in usage of Cake.Issues.Recipe you may need to check the release notes to confirm if there are any additional changes that need to be made.
 
 [Check out the blog post here for additional information](https://cakeissues.net/news/cake-issues-v2.0.0-released).
+
+### Codecov Coverage Uploads
+
+In this release of Cake.Recipe we have updated the support for Codecov to now
+require a token to be specified. If in your build scripts you have Codecov
+enabled by default, you will see this task being skipped if you have not already
+specified a token.
+
+[Check out Codecov documentation for adding a token](https://docs.codecov.com/docs/adding-the-codecov-token)


### PR DESCRIPTION
Codecov no longer officially supports tokenless coverage uploads.
While it may work in rare cases, it is more appropriate
for us to remove this support completely.
This PR makes these necessary changes to remove the support.

Additionally, this PR also updates the Cake.Codecov library to v2.0.0 and replaces the unofficial Codecov-exe project with the CodecovUploader that embeds the official Codecov CLI executables.

- fixes #999 
- fixes #1001