### PR TITLE
(GH-1009) Consider SetToolSettings.skipDuplicatePackages

### DIFF
--- a/Source/Cake.Recipe/Content/toolsettings.cake
+++ b/Source/Cake.Recipe/Content/toolsettings.cake
@@ -122,5 +122,6 @@ public static class ToolSettings
         {
             TargetFrameworkPathOverride = targetFrameworkPathOverride?.FullPath;
         }
+        SkipDuplicatePackages = skipDuplicatePackages;
     }
 }


### PR DESCRIPTION
Correctly set `SetToolSettings.SkipDuplicatePackages` if `skipDuplicatePackages` is passed to the static `SetToolSettings` method.

Fixes #1009 