### PR TITLE
Output InspectCode result in XML format

### DIFF
--- a/Source/Cake.Recipe/Content/analyzing.cake
+++ b/Source/Cake.Recipe/Content/analyzing.cake
@@ -10,7 +10,7 @@ BuildParameters.Tasks.InspectCodeTask = Task("InspectCode")
         var settings = new InspectCodeSettings() {
             SolutionWideAnalysis = true,
             OutputFile = inspectCodeLogFilePath,
-            ArgumentCustomization = x => x.Append("--no-build")
+            ArgumentCustomization = x => x.Append("--no-build").Append("-f=xml")
         };
 
         if (FileExists(BuildParameters.SourceDirectoryPath.CombineWithFilePath(BuildParameters.ResharperSettingsFileName)))


### PR DESCRIPTION
Latest InspectCode version generates a SARIF file by default. Enforce to write an XML file which Cake.Issues can parse.

Once we've updated to Cake Issues 3.x we can use the available SARIF parser.