### PR TITLE
(#1019) Update to use Cake 3.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.2.0",
+      "version": "3.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,5 +41,5 @@ jobs:
         with:
           script-path: recipe.cake
           target: CI
-          cake-version: 2.2.0
+          cake-version: 3.2.0
           cake-bootstrap: true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": ".NET Launch (console)",
             "type": "coreclr",
             "request": "launch",
             "program": "${workspaceRoot}/tools/Cake.CoreCLR/Cake.dll",

--- a/Source/Cake.Recipe/Content/addins.cake
+++ b/Source/Cake.Recipe/Content/addins.cake
@@ -2,21 +2,21 @@
 // ADDINS
 ///////////////////////////////////////////////////////////////////////////////
 
-#addin nuget:?package=Cake.Codecov&version=2.0.1
-#addin nuget:?package=Cake.Coveralls&version=2.0.0
-#addin nuget:?package=Cake.Coverlet&version=2.5.4
+#addin nuget:?package=Cake.Codecov&version=3.0.0
+#addin nuget:?package=Cake.Coveralls&version=3.0.0
+#addin nuget:?package=Cake.Coverlet&version=3.0.4
 #addin nuget:?package=Portable.BouncyCastle&version=1.8.5
 #addin nuget:?package=Cake.Email&version=2.0.0&loaddependencies=true
-#addin nuget:?package=Cake.Incubator&version=7.0.0
-#addin nuget:?package=Cake.Kudu&version=2.0.0
+#addin nuget:?package=Cake.Incubator&version=8.0.0
+#addin nuget:?package=Cake.Kudu&version=3.0.0
 #addin nuget:?package=Cake.MicrosoftTeams&version=2.0.0
 #addin nuget:?package=Cake.Slack&version=2.0.0
 #addin nuget:?package=Cake.Transifex&version=2.0.0
-#addin nuget:?package=Cake.Twitter&version=2.0.1
-#addin nuget:?package=Cake.Wyam&version=2.2.13
+#addin nuget:?package=Cake.Twitter&version=3.0.0
+#addin nuget:?package=Cake.Wyam&version=2.2.14
 #addin nuget:?package=Cake.Mastodon&version=1.1.0
 
-#load nuget:?package=Cake.Issues.Recipe&version=2.0.0
+#load nuget:?package=Cake.Issues.Recipe&version=3.1.1
 
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));

--- a/Source/Cake.Recipe/Content/codecov.cake
+++ b/Source/Cake.Recipe/Content/codecov.cake
@@ -6,7 +6,7 @@ BuildParameters.Tasks.UploadCodecovReportTask = Task("Upload-Codecov-Report")
     .WithCriteria(() => BuildParameters.IsMainRepository, "Skipping because not running from the main repository")
     .WithCriteria(() => BuildParameters.ShouldRunCodecov, "Skipping because uploading to codecov is disabled")
     .WithCriteria(() => BuildParameters.CanPublishToCodecov, "Skipping because repo token is missing, or not running on GitHub CI")
-    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.CodecovGlobalTool : ToolSettings.CodecovTool, () => {
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.CodecovGlobalTool : ToolSettings.CodecovTool, () => {
         var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.xml");
         if (FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
         {

--- a/Source/Cake.Recipe/Content/coveralls.cake
+++ b/Source/Cake.Recipe/Content/coveralls.cake
@@ -6,7 +6,7 @@ BuildParameters.Tasks.UploadCoverallsReportTask = Task("Upload-Coveralls-Report"
     .WithCriteria(() => !BuildParameters.IsLocalBuild)
     .WithCriteria(() => !BuildParameters.IsPullRequest)
     .WithCriteria(() => BuildParameters.IsMainRepository)
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.CoverallsGlobalTool : ToolSettings.CoverallsTool, () => {
+    .Does(() => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.CoverallsGlobalTool : ToolSettings.CoverallsTool, () => {
         if (BuildParameters.CanPublishToCoveralls)
         {
             var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.xml");

--- a/Source/Cake.Recipe/Content/gitreleasemanager.cake
+++ b/Source/Cake.Recipe/Content/gitreleasemanager.cake
@@ -3,7 +3,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 BuildParameters.Tasks.CreateReleaseNotesTask = Task("Create-Release-Notes")
-    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {
             var settings = new GitReleaseManagerCreateSettings
@@ -36,7 +36,7 @@ BuildParameters.Tasks.ExportReleaseNotesTask = Task("Export-Release-Notes")
     .WithCriteria(() => BuildParameters.IsTagged || BuildParameters.PrepareLocalRelease, "Is not a tagged build, and is not preparing local release")
     .WithCriteria(() => BuildParameters.PreferredBuildAgentOperatingSystem == BuildParameters.BuildAgentOperatingSystem, "Not running on preferred build agent operating system")
     .WithCriteria(() => BuildParameters.PreferredBuildProviderType == BuildParameters.BuildProvider.Type, "Not running on preferred build provider type")
-    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {
             if (BuildParameters.ShouldDownloadMilestoneReleaseNotes)
@@ -64,7 +64,7 @@ BuildParameters.Tasks.ExportReleaseNotesTask = Task("Export-Release-Notes")
 BuildParameters.Tasks.PublishGitHubReleaseTask = Task("Publish-GitHub-Release")
     .IsDependentOn("Package")
     .WithCriteria(() => BuildParameters.ShouldPublishGitHub)
-    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {
             // Concatenating FilePathCollections should make sure we get unique FilePaths
@@ -91,7 +91,7 @@ BuildParameters.Tasks.PublishGitHubReleaseTask = Task("Publish-GitHub-Release")
 });
 
 BuildParameters.Tasks.CreateDefaultLabelsTask = Task("Create-Default-Labels")
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
+    .Does(() => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, () => {
         if (BuildParameters.CanUseGitReleaseManager)
         {
             GitReleaseManagerLabel(BuildParameters.GitHub.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName);

--- a/Source/Cake.Recipe/Content/packages.cake
+++ b/Source/Cake.Recipe/Content/packages.cake
@@ -23,9 +23,9 @@ BuildParameters.Tasks.CreateChocolateyPackagesTask = Task("Create-Chocolatey-Pac
     }
 });
 
-BuildParameters.Tasks.DotNetCorePackTask = Task("DotNetCore-Pack")
-    .IsDependentOn("DotNetCore-Build")
-    .WithCriteria(() => BuildParameters.ShouldRunDotNetCorePack, "Packaging through .NET Core is disabled")
+BuildParameters.Tasks.DotNetPackTask = Task("DotNet-Pack")
+    .IsDependentOn("DotNet-Build")
+    .WithCriteria(() => BuildParameters.ShouldRunDotNetPack, "Packaging through .NET is disabled")
     .Does<BuildVersion>((context, buildVersion) =>
 {
     var projects = GetFiles(BuildParameters.SourceDirectoryPath + "/**/*.csproj")
@@ -35,8 +35,8 @@ BuildParameters.Tasks.DotNetCorePackTask = Task("DotNetCore-Pack")
 
     // We need to clone the settings class, so we don't
     // add additional properties to every other task.
-    var msBuildSettings = new DotNetCoreMSBuildSettings();
-    foreach (var kv in context.Data.Get<DotNetCoreMSBuildSettings>().Properties)
+    var msBuildSettings = new DotNetMSBuildSettings();
+    foreach (var kv in context.Data.Get<DotNetMSBuildSettings>().Properties)
     {
         string value = string.Join(" ", kv.Value);
         msBuildSettings.WithProperty(kv.Key, value);
@@ -47,7 +47,7 @@ BuildParameters.Tasks.DotNetCorePackTask = Task("DotNetCore-Pack")
         msBuildSettings.WithProperty("SymbolPackageFormat", "snupkg");
     }
 
-    var settings = new DotNetCorePackSettings {
+    var settings = new DotNetPackSettings {
         NoBuild = true,
         NoRestore = true,
         Configuration = BuildParameters.Configuration,
@@ -59,7 +59,7 @@ BuildParameters.Tasks.DotNetCorePackTask = Task("DotNetCore-Pack")
 
     foreach (var project in projects)
     {
-        DotNetCorePack(project.ToString(), settings);
+        DotNetPack(project.ToString(), settings);
     }
 });
 

--- a/Source/Cake.Recipe/Content/parameters.cake
+++ b/Source/Cake.Recipe/Content/parameters.cake
@@ -26,7 +26,7 @@ public static class BuildParameters
     public static bool IsPublishBuild { get; private set; }
     public static bool IsReleaseBuild { get; private set; }
     public static BranchType BranchType { get; private set; }
-    public static bool IsDotNetCoreBuild { get; set; }
+    public static bool IsDotNetBuild { get; set; }
     public static bool IsNuGetBuild { get; set; }
     public static bool TransifexEnabled { get; set; }
     public static bool PrepareLocalRelease { get; set; }
@@ -95,7 +95,7 @@ public static class BuildParameters
     public static bool ShouldRunInspectCode { get; private set; }
     public static bool ShouldRunCoveralls { get; private set; }
     public static bool ShouldRunCodecov { get; private set; }
-    public static bool ShouldRunDotNetCorePack { get; private set; }
+    public static bool ShouldRunDotNetPack { get; private set; }
     public static bool ShouldRunChocolatey { get; private set; }
     public static bool ShouldPublishGitHub { get; private set; }
     public static bool ShouldGenerateDocumentation { get; private set; }
@@ -289,7 +289,7 @@ public static class BuildParameters
         bool shouldRunInspectCode = true,
         bool shouldRunCoveralls = true,
         bool shouldRunCodecov = true,
-        bool shouldRunDotNetCorePack = false,
+        bool shouldRunDotNetPack = false,
         bool shouldBuildNugetSourcePackage = false,
         bool shouldRunIntegrationTests = false,
         bool shouldCalculateVersion = true,
@@ -380,7 +380,7 @@ public static class BuildParameters
         ShouldRunInspectCode = shouldRunInspectCode;
         ShouldRunCoveralls = shouldRunCoveralls;
         ShouldRunCodecov = shouldRunCodecov;
-        ShouldRunDotNetCorePack = shouldRunDotNetCorePack;
+        ShouldRunDotNetPack = shouldRunDotNetPack;
         ShouldBuildNugetSourcePackage = shouldBuildNugetSourcePackage;
         ShouldCalculateVersion = shouldCalculateVersion;
         _shouldUseDeterministicBuilds = shouldUseDeterministicBuilds;

--- a/Source/Cake.Recipe/Content/setup.cake
+++ b/Source/Cake.Recipe/Content/setup.cake
@@ -5,7 +5,7 @@ Setup<BuildVersion>(context =>
 {
     BuildVersion buildVersion = null;
 
-    RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.GitVersionGlobalTool : ToolSettings.GitVersionTool, () => {
+    RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.GitVersionGlobalTool : ToolSettings.GitVersionTool, () => {
         buildVersion = BuildVersion.CalculatingSemanticVersion(
                 context: Context
             );
@@ -64,12 +64,12 @@ Setup<BuildData>(context =>
     return new BuildData(context);
 });
 
-Setup<DotNetCoreMSBuildSettings>(context =>
+Setup<DotNetMSBuildSettings>(context =>
 {
     var buildVersion = context.Data.Get<BuildVersion>();
     var data = context.Data.Get<BuildData>(); // Future use
 
-    var settings = new DotNetCoreMSBuildSettings()
+    var settings = new DotNetMSBuildSettings()
                     .WithProperty("Version", buildVersion.SemVersion)
                     .WithProperty("AssemblyVersion", buildVersion.Version)
                     .WithProperty("FileVersion", buildVersion.Version)
@@ -81,7 +81,7 @@ Setup<DotNetCoreMSBuildSettings>(context =>
     }
     if (BuildParameters.ShouldUseTargetFrameworkPath)
     {
-        context.Information("Will use FrameworkPathOverride={0} on .NET Core build related tasks since not building on Windows.", ToolSettings.TargetFrameworkPathOverride);
+        context.Information("Will use FrameworkPathOverride={0} on .NET build related tasks since not building on Windows.", ToolSettings.TargetFrameworkPathOverride);
         settings.WithProperty("FrameworkPathOverride", ToolSettings.TargetFrameworkPathOverride);
     }
 

--- a/Source/Cake.Recipe/Content/tasks.cake
+++ b/Source/Cake.Recipe/Content/tasks.cake
@@ -7,11 +7,11 @@ public class BuildTasks
     public CakeTaskBuilder ClearAppVeyorCacheTask { get; set; }
     public CakeTaskBuilder ShowInfoTask { get; set; }
     public CakeTaskBuilder CleanTask { get; set; }
-    public CakeTaskBuilder DotNetCoreCleanTask { get; set; }
+    public CakeTaskBuilder DotNetCleanTask { get; set; }
     public CakeTaskBuilder RestoreTask { get; set; }
-    public CakeTaskBuilder DotNetCoreRestoreTask { get; set; }
+    public CakeTaskBuilder DotNetRestoreTask { get; set; }
     public CakeTaskBuilder BuildTask { get; set; }
-    public CakeTaskBuilder DotNetCoreBuildTask { get; set; }
+    public CakeTaskBuilder DotNetBuildTask { get; set; }
     public CakeTaskBuilder PackageTask { get; set; }
     public CakeTaskBuilder DefaultTask { get; set; }
     public CakeTaskBuilder ContinuousIntegrationTask { get; set; }
@@ -28,7 +28,7 @@ public class BuildTasks
     public CakeTaskBuilder ExportReleaseNotesTask { get; set; }
     public CakeTaskBuilder PublishGitHubReleaseTask { get; set; }
     public CakeTaskBuilder CreateDefaultLabelsTask { get; set; }
-    public CakeTaskBuilder DotNetCorePackTask { get; set; }
+    public CakeTaskBuilder DotNetPackTask { get; set; }
     public CakeTaskBuilder CreateNuGetPackageTask { get; set; }
     public CakeTaskBuilder CreateNuGetPackagesTask { get; set; }
     public CakeTaskBuilder PublishPreReleasePackagesTask { get; set; }
@@ -41,7 +41,7 @@ public class BuildTasks
     public CakeTaskBuilder TransifexPullTranslations { get; set; }
     public CakeTaskBuilder TransifexPushSourceResource { get; set; }
     public CakeTaskBuilder TransifexPushTranslations { get; set; }
-    public CakeTaskBuilder DotNetCoreTestTask { get; set; }
+    public CakeTaskBuilder DotNetTestTask { get; set; }
     public CakeTaskBuilder IntegrationTestTask { get;set; }
     public CakeTaskBuilder GenerateFriendlyTestReportTask { get; set; }
     public CakeTaskBuilder GenerateLocalCoverageReportTask { get; set; }

--- a/Source/Cake.Recipe/Content/testing.cake
+++ b/Source/Cake.Recipe/Content/testing.cake
@@ -107,9 +107,9 @@ BuildParameters.Tasks.TestVSTestTask = Task("Test-VSTest")
     }
 });
 
-BuildParameters.Tasks.DotNetCoreTestTask = Task("DotNetCore-Test")
+BuildParameters.Tasks.DotNetTestTask = Task("DotNet-Test")
     .IsDependentOn("Install-OpenCover")
-    .Does<DotNetCoreMSBuildSettings>((context, msBuildSettings) => {
+    .Does<DotNetMSBuildSettings>((context, msBuildSettings) => {
 
     var projects = GetFiles(BuildParameters.TestDirectoryPath + (BuildParameters.TestFilePattern ?? "/**/*Tests.csproj"));
     // We create the coverlet settings here so we don't have to create the filters several times
@@ -134,7 +134,7 @@ BuildParameters.Tasks.DotNetCoreTestTask = Task("DotNetCore-Test")
             coverletSettings.WithFilter(filter.TrimStart('-'));
         }
     }
-    var settings = new DotNetCoreTestSettings
+    var settings = new DotNetTestSettings
     {
         Configuration = BuildParameters.Configuration,
         NoBuild = true
@@ -144,7 +144,7 @@ BuildParameters.Tasks.DotNetCoreTestTask = Task("DotNetCore-Test")
     {
         Action<ICakeContext> testAction = tool =>
         {
-            tool.DotNetCoreTest(project.FullPath, settings);
+            tool.DotNetTest(project.FullPath, settings);
         };
 
         var parsedProject = ParseProject(project, BuildParameters.Configuration);
@@ -176,7 +176,7 @@ BuildParameters.Tasks.DotNetCoreTestTask = Task("DotNetCore-Test")
         if (parsedProject.IsNetCore && coverletPackage != null)
         {
             coverletSettings.CoverletOutputName = parsedProject.RootNameSpace.Replace('.', '-');
-            DotNetCoreTest(project.FullPath, settings, coverletSettings);
+            DotNetTest(project.FullPath, settings, coverletSettings);
         }
         else if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
         {
@@ -239,7 +239,7 @@ BuildParameters.Tasks.GenerateFriendlyTestReportTask = Task("Generate-FriendlyTe
 
 BuildParameters.Tasks.GenerateLocalCoverageReportTask = Task("Generate-LocalCoverageReport")
     .WithCriteria(() => BuildParameters.IsLocalBuild, "Skipping due to not running a local build")
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.ReportGeneratorGlobalTool : ToolSettings.ReportGeneratorTool, () => {
+    .Does(() => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.ReportGeneratorGlobalTool : ToolSettings.ReportGeneratorTool, () => {
         var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.xml");
         if (FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
         {
@@ -249,7 +249,7 @@ BuildParameters.Tasks.GenerateLocalCoverageReportTask = Task("Generate-LocalCove
         if (coverageFiles.Any())
         {
             var settings = new ReportGeneratorSettings();
-            if (BuildParameters.IsDotNetCoreBuild && BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
+            if (BuildParameters.IsDotNetBuild && BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
             {
                 // Workaround until 0.38.5+ version of cake is released
                 // https://github.com/cake-build/cake/pull/2824

--- a/Source/Cake.Recipe/Content/toolsettings.cake
+++ b/Source/Cake.Recipe/Content/toolsettings.cake
@@ -39,7 +39,7 @@ public static class ToolSettings
 
     public static void SetToolPreprocessorDirectives(
         string codecovTool = "#tool nuget:?package=CodecovUploader&version=0.8.0",
-        // This is specifically pinned to 0.7.0 as later versions of same package publish .Net Global Tool, rather than full framework version
+        // This is specifically pinned to 0.7.0 as later versions of same package publish .NET Global Tool, rather than full framework version
         string coverallsTool = "#tool nuget:?package=coveralls.net&version=0.7.0",
         string gitReleaseManagerTool = "#tool nuget:?package=GitReleaseManager&version=0.19.0",
         // This is specifically pinned to 5.0.1 as later versions break compatibility with Unix.
@@ -59,7 +59,7 @@ public static class ToolSettings
         string gitVersionGlobalTool = "#tool dotnet:?package=GitVersion.Tool&version=5.12.0",
         string reportGeneratorGlobalTool = "#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.8.5",
         string wyamGlobalTool = "#tool dotnet:?package=Wyam.Tool&version=2.2.9",
-        // This is using an unofficial build of kudusync so that we can have a .Net Global tool version.  This was generated from this PR: https://github.com/projectkudu/KuduSync.NET/pull/27
+        // This is using an unofficial build of kudusync so that we can have a .NET Global tool version.  This was generated from this PR: https://github.com/projectkudu/KuduSync.NET/pull/27
         string kuduSyncGlobalTool = "#tool dotnet:https://www.myget.org/F/cake-contrib/api/v3/index.json?package=KuduSync.Tool&version=1.5.4-g3916ad7218"
     )
     {

--- a/Source/Cake.Recipe/Content/wyam.cake
+++ b/Source/Cake.Recipe/Content/wyam.cake
@@ -12,7 +12,7 @@ BuildParameters.Tasks.PublishDocumentationTask = Task("Publish-Documentation")
     .IsDependentOn("Clean-Documentation")
     .WithCriteria(() => BuildParameters.ShouldGenerateDocumentation, "Wyam documentation has been disabled")
     .WithCriteria(() => DirectoryExists(BuildParameters.WyamRootDirectoryPath), "Wyam documentation directory is missing")
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.WyamGlobalTool : ToolSettings.WyamTool, () => {
+    .Does(() => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.WyamGlobalTool : ToolSettings.WyamTool, () => {
         // Check to see if any documentation has changed
         var sourceCommit = GitLogTip("./");
         Information("Source Commit Sha: {0}", sourceCommit.Sha);
@@ -94,7 +94,7 @@ BuildParameters.Tasks.PublishDocumentationTask = Task("Publish-Documentation")
 
 BuildParameters.Tasks.PreviewDocumentationTask = Task("Preview-Documentation")
     .WithCriteria(() => DirectoryExists(BuildParameters.WyamRootDirectoryPath), "Wyam documentation directory is missing")
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.WyamGlobalTool : ToolSettings.WyamTool, () => {
+    .Does(() => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.WyamGlobalTool : ToolSettings.WyamTool, () => {
         var settings = new Dictionary<string, object>
         {
             { "Host",  BuildParameters.WebHost },
@@ -127,7 +127,7 @@ BuildParameters.Tasks.PreviewDocumentationTask = Task("Preview-Documentation")
 BuildParameters.Tasks.ForcePublishDocumentationTask = Task("Force-Publish-Documentation")
     .IsDependentOn("Clean-Documentation")
     .WithCriteria(() => DirectoryExists(BuildParameters.WyamRootDirectoryPath), "Wyam documentation directory is missing")
-    .Does(() => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.WyamGlobalTool : ToolSettings.WyamTool, () => {
+    .Does(() => RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.WyamGlobalTool : ToolSettings.WyamTool, () => {
         var settings = new Dictionary<string, object>
         {
             { "Host",  BuildParameters.WebHost },
@@ -159,7 +159,7 @@ BuildParameters.Tasks.ForcePublishDocumentationTask = Task("Force-Publish-Docume
 
 public void PublishDocumentation()
 {
-    RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.KuduSyncGlobalTool : ToolSettings.KuduSyncTool, () => {
+    RequireTool(BuildParameters.IsDotNetBuild ? ToolSettings.KuduSyncGlobalTool : ToolSettings.KuduSyncTool, () => {
         if (BuildParameters.CanUseWyam)
         {
             var sourceCommit = GitLogTip("./");

--- a/Source/Cake.Recipe/cake-version.yml
+++ b/Source/Cake.Recipe/cake-version.yml
@@ -1,2 +1,2 @@
-TargetCakeVersion: 2.0.0
+TargetCakeVersion: 3.0.0
 TargetFrameworks: []

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 
 $SCRIPT_NAME = "recipe.cake"
 
-Write-Host "Restoring .NET Core tools"
+Write-Host "Restoring .NET tools"
 dotnet tool restore
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Restoring .NET Core tools"
+echo "Restoring .NET tools"
 dotnet tool restore
 
 if [ -f "./includes.cake" ]; then

--- a/docs/input/docs/fundamentals/build.md
+++ b/docs/input/docs/fundamentals/build.md
@@ -10,10 +10,10 @@ Cake.Recipe has three different entry points.  At the end of the recipe.cake fil
 Build.Run();
 ```
 
-which will execute the Cake.Recipe steps including executing MSBuild, and .Net Framework unit testing libraries such as Xunit, and NUnit.
+which will execute the Cake.Recipe steps including executing MSBuild, and .NET Framework unit testing libraries such as Xunit, and NUnit.
 
 ```csharp
-Build.RunDotNetCore();
+Build.RunDotNet();
 ```
 
 which will execute the Cake.Recipe steps including executing `dotnet build`, and `dotnet test`.

--- a/docs/input/docs/fundamentals/recipe-cake.md
+++ b/docs/input/docs/fundamentals/recipe-cake.md
@@ -28,7 +28,7 @@ ToolSettings.SetToolSettings(context: Context,
                             testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
                             testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
 
-Build.RunDotNetCore();
+Build.RunDotNet();
 ```
 
 The above content was generated using the [Cake.Recipe extension for VSCode](../vscode-extension), using the following input values:
@@ -51,4 +51,4 @@ This recipe.cake file is broken up to distinct sections, some of which have more
 * A call to the [ToolSettings.SetToolSettings](./set-tool-settings) method
   * Cake.Recipe uses a number of different tools, for example, InspectCode.  When required, you can override the settings that are passed to these tools.  Cake.Recipe attempts to provide sensible defaults for these tools.
 * A call to one of the three available [Build](./build) methods
-  * Cake.Recipe has three different build modes.  .NET Framework, .NET Core and NuGet.  Depending on what you are doing, you call the required one here.  This method is what causes the actual build to execute.
+  * Cake.Recipe has three different build modes.  .NET Framework, .NET and NuGet.  Depending on what you are doing, you call the required one here.  This method is what causes the actual build to execute.

--- a/docs/input/docs/fundamentals/set-parameters.md
+++ b/docs/input/docs/fundamentals/set-parameters.md
@@ -63,7 +63,7 @@ The SetParameters method uses the concept of optional parameters, in fact, all b
 
 ### solutionFilePath
 
-Cake.Recipe assumes that it is only building a single .Net solution file, and it needs to know the location of it.  It will attempt to form that location using the SourceDirectoryPath and the Title that are passed into SetParameters.
+Cake.Recipe assumes that it is only building a single .NET solution file, and it needs to know the location of it.  It will attempt to form that location using the SourceDirectoryPath and the Title that are passed into SetParameters.
 
 Type: `FilePath`
 
@@ -103,7 +103,7 @@ This is the pattern that is used to determine what files/projects should be run 
 
 Type: `string`
 
-Default Value: `"/**/*Tests.dll"` or `"/**/*Tests.csproj"` depending on whether it is a .Net Framework or .Net Core execution.
+Default Value: `"/**/*Tests.dll"` or `"/**/*Tests.csproj"` depending on whether it is a .NET Framework or .NET execution.
 
 ### integrationTestScriptPath
 
@@ -290,7 +290,7 @@ false
 
 ### shouldUseDeterministicBuilds
 
-If this parameter is set to true, then during the execution of either MSBuild or the .Net Core CLI, a build property called `ContinuousIntegrationBuild` with the value of `true` will be added.
+If this parameter is set to true, then during the execution of either MSBuild or the .NET CLI, a build property called `ContinuousIntegrationBuild` with the value of `true` will be added.
 
 Type: `bool`
 
@@ -408,9 +408,9 @@ Default Value:
 true
 ```
 
-### shouldRunDotNetCorePack
+### shouldRunDotNetPack
 
-By default, Cake.Recipe assumes that any NuGet packages are generated via the presence of nuspec files in correct folder.  However, it is possible to force the execution of .Net Core pack by setting this parameter to true.
+By default, Cake.Recipe assumes that any NuGet packages are generated via the presence of nuspec files in correct folder.  However, it is possible to force the execution of .NET pack by setting this parameter to true.
 
 Type: `bool`
 
@@ -422,8 +422,8 @@ false
 
 ### shouldBuildNugetSourcePackage
 
-When this is set to true, a number of different settings are enabled, for example, during the execution of the .Net Core CLI or NuGet, a build property called
-`SymbolPackageFormat` is set to `true`, and also the DotNetCorePackSettings properties IncludeSource and IncludeSymbols are set to true, and finally the NuGetPackSettings property Symbols is set to true.
+When this is set to true, a number of different settings are enabled, for example, during the execution of the .NET CLI or NuGet, a build property called
+`SymbolPackageFormat` is set to `true`, and also the DotNetPackSettings properties IncludeSource and IncludeSymbols are set to true, and finally the NuGetPackSettings property Symbols is set to true.
 
 Type: `bool`
 

--- a/docs/input/docs/fundamentals/set-tool-settings.md
+++ b/docs/input/docs/fundamentals/set-tool-settings.md
@@ -61,7 +61,7 @@ Default Value:
 
 ### buildPlatformTarget
 
-This is passed into the execution of MSBuild when doing a full .Net Framework build.
+This is passed into the execution of MSBuild when doing a full .NET Framework build.
 
 Type: `PlatformTarget?`
 
@@ -73,7 +73,7 @@ PlatformTarget.MSIL
 
 ### buildMSBuildToolVersion
 
-This is passed into the execution of MSBuild when doing a full .Net Framework build.
+This is passed into the execution of MSBuild when doing a full .NET Framework build.
 
 Type: `MSBuildToolVersion`
 
@@ -85,7 +85,7 @@ MSBuildToolVersion.Default
 
 ### maxCpuCount
 
-This is passed into the execution of MSBuild when doing a full .Net Framework build.
+This is passed into the execution of MSBuild when doing a full .NET Framework build.
 
 Type: `int?`
 
@@ -93,13 +93,13 @@ Default Value: 0
 
 ### targetFrameworkPathOverride
 
-This is passed into the execution of any .Net Core build operation.
+This is passed into the execution of any .NET build operation.
 
 Type: `DirectoryPath`
 
 Depending on what sort of build Cake.Recipe is executing, the default value changes.
 
-If `BuildParameters.ShouldUseTargetFrameworkPath` is true, and the `targetFrameworkPathOverride` is null, and it is a .Net Core build, then the default value is:
+If `BuildParameters.ShouldUseTargetFrameworkPath` is true, and the `targetFrameworkPathOverride` is null, and it is a .NET build, then the default value is:
 
 ```csharp
 var path = context.Tools.Resolve("mono").GetDirectory();
@@ -107,7 +107,7 @@ path = path.Combine("../lib/mono/4.5");
 TargetFrameworkPathOverride = path.FullPath + "/"
 ```
 
-If `BuildParameters.ShouldUseTargetFrameworkPath` is true, and the `targetFrameworkPathOverride` is null, and it is _NOT_ a .Net Core build, then the default value is:
+If `BuildParameters.ShouldUseTargetFrameworkPath` is true, and the `targetFrameworkPathOverride` is null, and it is _NOT_ a .NET build, then the default value is:
 
 ```csharp
 TargetFrameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/"

--- a/docs/input/docs/known-issues/running-xunit-tests-on-net-framework.md
+++ b/docs/input/docs/known-issues/running-xunit-tests-on-net-framework.md
@@ -1,10 +1,10 @@
 ---
 Order: 10
-Title: Running Xunit Tests when targeting .Net Framework
+Title: Running Xunit Tests when targeting .NET Framework
 Description: Can cause problems when running on a non-Windows Operating System
 ---
 
-There is a known issue that can occur when attempting to run Cake.Recipe (on a non Windows environment) against full .Net Framework when the solution that is being built includes an Xunit Test Project.
+There is a known issue that can occur when attempting to run Cake.Recipe (on a non Windows environment) against full .NET Framework when the solution that is being built includes an Xunit Test Project.
 
 The error that can appear is:
 

--- a/docs/input/docs/overview/features.md
+++ b/docs/input/docs/overview/features.md
@@ -6,7 +6,7 @@ Description: Overview about core features
 
 Cake.Recipe is a set of convention based build scripts, which are delivered as a NuGet Package, which can then be consumed by Cake, via the `#load` preprocessor directive.
 
-Cake.Recipe runs under both .Net Framework and .Net Core.
+Cake.Recipe runs under both .NET Framework and .NET.
 
 ## Recipe Functionality
 

--- a/docs/input/docs/overview/requirements/posix.md
+++ b/docs/input/docs/overview/requirements/posix.md
@@ -7,8 +7,8 @@ Description: Requirements for running Cake.Recipe on Posix
 ## Required Framework Version
 
 In order to run Cake.Recipe on a Posix machine (i.e. Mac or Linux) it is necessary to have, as a minimum, mono 5.16.x.
-If you will be building .NET Core project, Cake.Recipe will automatically use .NET Core editions of tools when possible.
-In these cases there is a requirement of having .NET Core 3.1 installed.
+If you will be building .NET project, Cake.Recipe will automatically use .NET editions of tools when possible.
+In these cases there is a requirement of having .NET 3.1 installed.
 
 :::::
 
@@ -33,7 +33,7 @@ To install the necessary requirements when running on Mac OSX, you can use homeb
 brew cask install mono-mdk
 ```
 
-For installing .NET Core on OSX, please see the [Microsoft documentation](https://docs.microsoft.com/nb-no/dotnet/core/install/macos)
+For installing .NET on OSX, please see the [Microsoft documentation](https://docs.microsoft.com/nb-no/dotnet/core/install/macos)
 
 :::
 
@@ -51,10 +51,10 @@ apt-get install mono-complete ca-certificates-mono
 
 _NOTE: The `ca-certificates-mono` package may be omitted on modern Ubuntu versions_.
 
-To install .NET Core on Ubuntu, please follow the [Microsoft documentation](https://docs.microsoft.com/nb-no/dotnet/core/install/macos) for how
+To install .NET on Ubuntu, please follow the [Microsoft documentation](https://docs.microsoft.com/nb-no/dotnet/core/install/macos) for how
 to add the necessary repository.
 
-After adding the repository, run the following command to install .NET Core.
+After adding the repository, run the following command to install .NET.
 
 ```shell
 apt-get install dotnet-runtime-3.1 dotnet-sdk-3.1
@@ -71,13 +71,13 @@ To install the necessary requirements for Arch Linux and Manjaro, run the follow
 pacman -S mono
 ```
 
-To install .NET Core on Arch Linux, you can install the 3.1 version with the following command
+To install .NET on Arch Linux, you can install the 3.1 version with the following command
 
 ```console
 pacman -S dotnet-runtime dotnet-sdk
 ```
 
-_NOTE: .NET Core sdk 2.1 is available in [AUR](https://aur.archlinux.org/packages/dotnet-sdk-2.1) under the name `dotnet-sdk-2.1`_.
+_NOTE: .NET sdk 2.1 is available in [AUR](https://aur.archlinux.org/packages/dotnet-sdk-2.1) under the name `dotnet-sdk-2.1`_.
 
 :::
 

--- a/docs/input/docs/overview/requirements/windows.md
+++ b/docs/input/docs/overview/requirements/windows.md
@@ -6,14 +6,14 @@ Description: Requirements for running Cake.Recipe on Windows
 
 ## Required Framework Version
 
-In order to run Cake.Recipe on a Windows machine it is necessary to have, as a minimum, .Net Framework 4.7.2. This can be installed via Chocolatey using:
+In order to run Cake.Recipe on a Windows machine it is necessary to have, as a minimum, .NET Framework 4.7.2. This can be installed via Chocolatey using:
 
 ```bash
 choco install dotnet4.7.2
 ```
 
-If you will be building .NET Core project, Cake.Recipe will automatically use .NET Core editions of tools when possible.
-In these cases there is a requirement of having .NET Core 3.1 installed.
+If you will be building .NET Project, Cake.Recipe will automatically use .NET editions of tools when possible.
+In these cases there is a requirement of having .NET 3.1 installed.
 
 This can easily be installed through Chocolatey using:
 

--- a/docs/input/docs/upgrading/1.x-to-2.x.md
+++ b/docs/input/docs/upgrading/1.x-to-2.x.md
@@ -34,7 +34,7 @@ Cake.Recipe 1.x.x was pinned to run against version 0.32.1 of Cake.  In order to
 
 ### Update bootstrapper to include --bootstrap command
 
-Cake.Recipe now includes the use of the .Net Global Tool Module.  As such, it will be necessary to first bootstrap this module before executing the build.  That can be done as follows:
+Cake.Recipe now includes the use of the .NET Global Tool Module.  As such, it will be necessary to first bootstrap this module before executing the build.  That can be done as follows:
 
 ```powershell
 Write-Host "Bootstrapping Cake"
@@ -64,7 +64,7 @@ build_script:
 
 ### Update GitVersion.yml file with the required changes for using new version of GitVersion
 
-Cake.Recipe has switched from using 3.6.5 of GitVersion, to 5.0.1 of the .Net Framework version, and 5.3.7 of the .Net Global Tool version.  There have been a number of breaking changes in how GitVersion configuration works, specifically around how branches are configured.  If you have done any branch configuration in the GitVersion.yml file, you may have to update to the [latest standards](https://gitversion.net/docs/configuration#branch-configuration).
+Cake.Recipe has switched from using 3.6.5 of GitVersion, to 5.0.1 of the .NET Framework version, and 5.3.7 of the .NET Global Tool version.  There have been a number of breaking changes in how GitVersion configuration works, specifically around how branches are configured.  If you have done any branch configuration in the GitVersion.yml file, you may have to update to the [latest standards](https://gitversion.net/docs/configuration#branch-configuration).
 
 ### Ensure AppVeyor build image is using the latest
 
@@ -101,7 +101,7 @@ Due to the fact that Cake.Recipe has now enabled fully deterministic builds by d
 To facilitate this, you will need to add the following parameter:
 
 ```csharp
-shouldRunDotNetCorePack: true
+shouldRunDotNetPack: true
 ```
 
 ### Add Cake.Addin.Analyzer package
@@ -150,9 +150,9 @@ Now that Cake.Recipe supports other platforms than just AppVeyor, we recommend a
 
 ### Switch to Cake.Tool rather than Cake.exe
 
-Since Cake.Recipe now fully supports running on .Net Core, we are also recommending that you switch to use the .Net Global Tool version of Cake.  This includes using a `.config/dotnet-tools.json` file to pin to a specific version of Cake.  More information on switching to this can be found in the [Cake docs](https://cakebuild.net/docs/getting-started/setting-up-a-new-project).
+Since Cake.Recipe now fully supports running on .NET, we are also recommending that you switch to use the .NET Global Tool version of Cake.  This includes using a `.config/dotnet-tools.json` file to pin to a specific version of Cake.  More information on switching to this can be found in the [Cake docs](https://cakebuild.net/docs/getting-started/setting-up-a-new-project).
 
-### Update bootstrappers to use .Net Global Tool
+### Update bootstrappers to use .NET Global Tool
 
 An example of a build.ps1 file that can be used is:
 
@@ -161,7 +161,7 @@ $ErrorActionPreference = 'Stop'
 
 $SCRIPT_NAME = "recipe.cake"
 
-Write-Host "Restoring .NET Core tools"
+Write-Host "Restoring .NET tools"
 dotnet tool restore
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -180,7 +180,7 @@ An example of a build.sh file that can be used is:
 #!/bin/bash
 SCRIPT_NAME="recipe.cake"
 
-echo "Restoring .NET Core tools"
+echo "Restoring .NET tools"
 dotnet tool restore
 
 echo "Bootstrapping Cake"
@@ -206,7 +206,7 @@ However, now that the packages.config file is no longer being used, and the tool
 
 ### Delete packages.config file
 
-Since we are recommending switching to using the .Net Global Tool version of Cake, with associated bootstrappers, the packages.config file in the tools folder is no longer required, and can be deleted.  In addition, you should update the .gitignore file to remove the special handling of this file.
+Since we are recommending switching to using the .NET Global Tool version of Cake, with associated bootstrappers, the packages.config file in the tools folder is no longer required, and can be deleted.  In addition, you should update the .gitignore file to remove the special handling of this file.
 
 ### Ensure there are no trailing spaces in the recipe.cake file for the testCoverageFilter parameter
 

--- a/docs/input/docs/usage/code-coverage-reports.md
+++ b/docs/input/docs/usage/code-coverage-reports.md
@@ -17,7 +17,7 @@ Upload-Coveralls-Report
 No coverage statistics files.
 ```
 
-OpenCover doesn't support the [portable debug type](https://github.com/dotnet/core/blob/e6049bb60307d987e044c39a106e0d6cf98857a3/Documentation/diagnostics/portable_pdb.md), which is the default of a .NET Core project. The resolution is to change or add a `DebugType` node in your `netcoreapp` test project and **all** projects it covers.  Acceptable options are `full` or `pdbonly`.  After adding one of the following xml tags to each project in your solution that tests, or is tested by a `netstandard` or `netcoreapp` project, OpenCover will produce a valid coverage file and upload to coveralls.
+OpenCover doesn't support the [portable debug type](https://github.com/dotnet/core/blob/e6049bb60307d987e044c39a106e0d6cf98857a3/Documentation/diagnostics/portable_pdb.md), which is the default of a .NET project. The resolution is to change or add a `DebugType` node in your `netcoreapp` test project and **all** projects it covers.  Acceptable options are `full` or `pdbonly`.  After adding one of the following xml tags to each project in your solution that tests, or is tested by a `netstandard` or `netcoreapp` project, OpenCover will produce a valid coverage file and upload to coveralls.
 
 ``` xml
   <PropertyGroup>

--- a/docs/input/docs/usage/conventions.md
+++ b/docs/input/docs/usage/conventions.md
@@ -34,10 +34,10 @@ As set out in the introduction [Cake.Recipe is a set of convention based build s
 
 * Building class library
 
-  When you are writing a reusable library, you are going to want to publish your code as a NuGet package for reuse. Whether you are writing .Net Framework based or .Net Standard based code, the recipe's intent will be to build your code, package using your nuspec file and publish. Best practices demand that your tests succeed and you meet your basic code quality criteria. All of these are turned on by default, may be turned off in the above `SetParameters` argument list.
+  When you are writing a reusable library, you are going to want to publish your code as a NuGet package for reuse. Whether you are writing .NET Framework based or .NET Standard based code, the recipe's intent will be to build your code, package using your nuspec file and publish. Best practices demand that your tests succeed and you meet your basic code quality criteria. All of these are turned on by default, may be turned off in the above `SetParameters` argument list.
 
-  * To build a .Net Core package, the command `Build.RunDotNetCore()`
-  * To build a .Net framework package, the command `Build.Run()` is followed with `Build.RunNuGet()`, to do a NuGet package and publish.
+  * To build a .NET package, the command `Build.RunDotNet()`
+  * To build a .NET framework package, the command `Build.Run()` is followed with `Build.RunNuGet()`, to do a NuGet package and publish.
 
 * Building MSI
 

--- a/recipe.cake
+++ b/recipe.cake
@@ -22,7 +22,7 @@ BuildParameters.SetParameters(context: Context,
                             shouldRunInspectCode: false,
                             shouldRunCoveralls: false,
                             shouldRunCodecov: false,
-                            shouldRunDotNetCorePack: true,
+                            shouldRunDotNetPack: true,
                             twitterMessage: standardNotificationMessage,
                             shouldGenerateDocumentation: false);
 
@@ -68,8 +68,8 @@ Task("Run-Local-Integration-Tests")
 });
 
 Task("Set-CakeVersion-InBuild")
-    .IsDependeeOf("DotNetCore-Build")
-    .Does<DotNetCoreMSBuildSettings>((context, msBuildSettings) => 
+    .IsDependeeOf("DotNet-Build")
+    .Does<DotNetMSBuildSettings>((context, msBuildSettings) => 
 {
     var cakeVersion = FileReadLines(File("./Source/Cake.Recipe/cake-version.yml"))
         .Where(x => x.StartsWith("TargetCakeVersion:"))
@@ -86,4 +86,4 @@ Task("Set-CakeVersion-InBuild")
     msBuildSettings.WithProperty("CakeVersion", cakeVersion);
 });
 
-Build.RunDotNetCore();
+Build.RunDotNet();


### PR DESCRIPTION
This has been a LONG time coming, but with the release of Cake.Recipe 4.0.0 which supports Cake 2.0.0, let's move forward with the next release to support Cake 3.0.0.